### PR TITLE
Corresponding deployment descriptor elements should be discussed by resource definition annotations

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -70,9 +70,28 @@ import java.lang.annotation.Target;
  * If {@link #ALL_REMAINING} is not present in any of the lists, it is
  * implicitly appended to the {@link #cleared()} context types.</p>
  *
+ * You can also define a {@code ContextService} with the
+ * {@code <context-service>} deployment descriptor element.
+ * For example,
+ *
+ * <pre>
+ * &lt;context-service&gt;
+ *    &lt;name&gt;java:app/concurrent/MyContext&lt;/name&gt;
+ *    &lt;cleared&gt;Security&lt;/cleared&gt;
+ *    &lt;cleared&gt;Transaction&lt;/cleared&gt;
+ *    &lt;propagated&gt;Application&lt;/propagated&gt;
+ *    &lt;unchanged&gt;Remaining&lt;/unchanged&gt;
+ * &lt;/context-service&gt;
+ * </pre>
+ *
+ * If a {@code context-service} and {@code ContextServiceDefinition}
+ * have the same name, their attributes are merged to define a single
+ * {@code ContextService} definition, with each attribute that is specified
+ * in the {@code context-service} deployment descriptor entry taking
+ * precedence over the corresponding attribute of the annotation.
+ *
  * @since 3.0
  */
-// TODO could mention relation with <context-service> definition in deployment descriptor once that is added
 @Repeatable(ContextServiceDefinition.List.class)
 @Retention(RUNTIME)
 @Target(TYPE)

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -33,14 +33,16 @@ import java.lang.annotation.Target;
  * {@link jakarta.annotation.Resource#lookup() lookup} attribute of a
  * {@link jakarta.annotation.Resource} annotation,</p>
  *
- * <pre>{@literal @}ManagedExecutorDefinition(
+ * <pre>
+ * {@literal @}ManagedExecutorDefinition(
  *     name = "java:module/concurrent/MyExecutor",
+ *     context = "java:module/concurrent/MyExecutorContext",
  *     hungTaskThreshold = 120000,
- *     maxAsync = 5,
- *     context ={@literal @}ContextServiceDefinition(
- *               name = "java:module/concurrent/MyExecutorContext",
- *               propagated = { SECURITY, APPLICATION }))
- * public class MyServlet extends HttpServlet {
+ *     maxAsync = 5)
+ * {@literal @}ContextServiceDefinition(
+ *     name = "java:module/concurrent/MyExecutorContext",
+ *     propagated = { SECURITY, APPLICATION })
+ *  public class MyServlet extends HttpServlet {
  *    {@literal @}Resource(lookup = "java:module/concurrent/MyExecutor",
  *               name = "java:module/concurrent/env/MyExecutorRef")
  *     ManagedExecutorService myExecutor;
@@ -57,9 +59,27 @@ import java.lang.annotation.Target;
  * &lt;/resource-env-ref&gt;
  * </pre>
  *
+ * You can also define a {@code ManagedExecutorService} with the
+ * {@code <managed-executor>} deployment descriptor element.
+ * For example,
+ *
+ * <pre>
+ * &lt;managed-executor&gt;
+ *    &lt;name&gt;java:module/concurrent/MyExecutor&lt;/name&gt;
+ *    &lt;context-service-ref&gt;java:module/concurrent/MyExecutorContext&lt;/context-service-ref&gt;
+ *    &lt;hung-task-threshold&gt;120000&lt;/hung-task-threshold&gt;
+ *    &lt;max-async&gt;5&lt;/max-async&gt;
+ * &lt;/managed-executor&gt;
+ * </pre>
+ *
+ * If a {@code managed-executor} and {@code ManagedExecutorDefinition}
+ * have the same name, their attributes are merged to define a single
+ * {@code ManagedExecutorService} definition, with each attribute that is specified
+ * in the {@code managed-executor} deployment descriptor entry taking
+ * precedence over the corresponding attribute of the annotation.
+ *
  * @since 3.0
  */
-//TODO could mention relation with <managed-executor> definition in deployment descriptor once that is added
 @Repeatable(ManagedExecutorDefinition.List.class)
 @Retention(RUNTIME)
 @Target(TYPE)
@@ -80,17 +100,22 @@ public @interface ManagedExecutorDefinition {
     String name();
 
     /**
-     * <p>Determines how context is applied to tasks and actions that
-     * run on this executor.</p>
+     * The name of a {@link ContextService} instance which
+     * determines how context is applied to tasks and actions that
+     * run on this executor.
+     * <p>
+     * The name can be the name of a {@link ContextServiceDefinition} or
+     * the name of a {@code context-service} deployment descriptor element
+     * or the JNDI name of the Jakarta EE default {@code ContextService}
+     * instance, {@code java:comp/DefaultContextService}.
+     * <p>
+     * The default value, {@code java:comp/DefaultContextService}, is the
+     * JNDI name of the Jakarta EE default {@code ContextService}.
      *
-     * <p>The default value indicates to use the default instance of
-     * {@link ContextService} by specifying a
-     * {@link ContextServiceDefinition} with the name
-     * <code>java:comp/DefaultContextService</code>.</p>
-     *
-     * @return instructions for capturing and propagating or clearing context.
+     * @return name of the {@code ContextService} for
+     *         capturing and propagating or clearing context.
      */
-    ContextServiceDefinition context() default @ContextServiceDefinition(name = "java:comp/DefaultContextService");
+    String context() default "java:comp/DefaultContextService";
 
     /**
      * <p>The amount of time in milliseconds that a task or action

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -33,13 +33,15 @@ import java.lang.annotation.Target;
  * {@link jakarta.annotation.Resource#lookup() lookup} attribute of a
  * {@link jakarta.annotation.Resource} annotation,</p>
  *
- * <pre>{@literal @}ManagedThreadFactoryDefinition(
+ * <pre>
+ * {@literal @}ManagedThreadFactoryDefinition(
  *     name = "java:global/concurrent/MyThreadFactory",
- *     priority = "4",
- *     context ={@literal @}ContextServiceDefinition(
- *               name = "java:global/concurrent/MyThreadFactoryContext",
- *               propagated = APPLICATION))
- * public class MyServlet extends HttpServlet {
+ *     context = "java:global/concurrent/MyThreadFactoryContext",
+ *     priority = 4)
+ * {@literal @}ContextServiceDefinition(
+ *     name = "java:global/concurrent/MyThreadFactoryContext",
+ *     propagated = APPLICATION)
+ *  public class MyServlet extends HttpServlet {
  *    {@literal @}Resource(lookup = "java:global/concurrent/MyThreadFactory",
  *               name = "java:module/concurrent/env/MyThreadFactoryRef")
  *     ManagedThreadFactory myThreadFactory;
@@ -56,9 +58,26 @@ import java.lang.annotation.Target;
  * &lt;/resource-env-ref&gt;
  * </pre>
  *
+ * You can also define a {@code ManagedThreadFactory} with the
+ * {@code <managed-thread-factory>} deployment descriptor element.
+ * For example,
+ *
+ * <pre>
+ * &lt;managed-thread-factory&gt;
+ *    &lt;name&gt;java:global/concurrent/MyThreadFactory&lt;/name&gt;
+ *    &lt;context-service-ref&gt;java:global/concurrent/MyThreadFactoryContext&lt;/context-service-ref&gt;
+ *    &lt;priority&gt;4&lt;/priority&gt;
+ * &lt;/managed-thread-factory&gt;
+ * </pre>
+ *
+ * If a {@code managed-thread-factory} and {@code ManagedThreadFactoryDefinition}
+ * have the same name, their attributes are merged to define a single
+ * {@code ManagedThreadFactory} definition, with each attribute that is specified
+ * in the {@code managed-thread-factory} deployment descriptor entry taking
+ * precedence over the corresponding attribute of the annotation.
+ *
  * @since 3.0
  */
-//TODO could mention relation with <managed-thread-factory> definition in deployment descriptor once that is added
 @Repeatable(ManagedThreadFactoryDefinition.List.class)
 @Retention(RUNTIME)
 @Target(TYPE)
@@ -89,7 +108,7 @@ public @interface ManagedThreadFactoryDefinition {
      *
      * @return instructions for capturing and propagating or clearing context.
      */
-    ContextServiceDefinition context() default @ContextServiceDefinition(name = "java:comp/DefaultContextService");
+    String context() default "java:comp/DefaultContextService";
 
     /**
      * <p>Priority for threads created by this thread factory.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/spi/ThreadContextProvider.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/spi/ThreadContextProvider.java
@@ -112,14 +112,11 @@ public interface ThreadContextProvider {
      * <p>
      * For example:
      * <pre>
-     * {@code @ManagedExecutorDefinition(}
-     *  name = "java:module/concurrent/MyCustomContextExecutor",
-     *  maxAsync = 3,
-     *  context = {@code @ContextServiceDefinition(}
-     *             name = "java:module/concurrent/MyCustomContext",
-     *             propagated = MyCustomContextProvider.CONTEXT_NAME,
-     *             cleared = { ContextServiceDefinition.SECURITY, ContextServiceDefinition.TRANSACTION },
-     *             unchanged = ContextServiceDefinition.ALL_REMAINING))
+     * {@code @ContextServiceDefinition(}
+     *    name = "java:module/concurrent/MyCustomContext",
+     *    propagated = MyCustomContextProvider.CONTEXT_NAME,
+     *    cleared = { ContextServiceDefinition.SECURITY, ContextServiceDefinition.TRANSACTION },
+     *    unchanged = ContextServiceDefinition.ALL_REMAINING)
      * </pre>
      * <p>
      * It is an error for multiple thread context providers of an identical type to be

--- a/api/src/test/java/jakarta/enterprise/concurrent/ManagedExecutorDefinitionTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ManagedExecutorDefinitionTest.java
@@ -27,11 +27,12 @@ import org.junit.Test;
 
 @ManagedExecutorDefinition( // from ManagedExecutorDefinition JavaDoc
         name = "java:module/concurrent/MyExecutor",
+        context = "java:module/concurrent/MyExecutorContext",
         hungTaskThreshold = 120000,
-        maxAsync = 5,
-        context = @ContextServiceDefinition(
-                  name = "java:module/concurrent/MyExecutorContext",
-                  propagated = { SECURITY, APPLICATION }))
+        maxAsync = 5)
+@ContextServiceDefinition( // from ManagedExecutorDefinition JavaDoc, used by above
+        name = "java:module/concurrent/MyExecutorContext",
+        propagated = { SECURITY, APPLICATION })
 @ManagedExecutorDefinition(
         name = "java:app/concurrent/ManagedExecutorDefinitionDefaults")
 public class ManagedExecutorDefinitionTest {
@@ -53,11 +54,7 @@ public class ManagedExecutorDefinitionTest {
         assertNotNull(def);
         assertEquals(-1, def.hungTaskThreshold());
         assertEquals(-1, def.maxAsync());
-        ContextServiceDefinition csd = def.context();
-        assertEquals("java:comp/DefaultContextService", csd.name());
-        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
-        assertArrayEquals(new String[] {}, csd.unchanged());
-        assertArrayEquals(new String[] { ALL_REMAINING }, csd.propagated());
+        assertEquals("java:comp/DefaultContextService", def.context());
     }
 
     /**
@@ -72,10 +69,6 @@ public class ManagedExecutorDefinitionTest {
         assertNotNull(def);
         assertEquals(120000, def.hungTaskThreshold());
         assertEquals(5, def.maxAsync());
-        ContextServiceDefinition csd = def.context();
-        assertEquals("java:module/concurrent/MyExecutorContext", csd.name());
-        assertArrayEquals(new String[] { SECURITY, APPLICATION }, csd.propagated());
-        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
-        assertArrayEquals(new String[] {}, csd.unchanged());
+        assertEquals("java:module/concurrent/MyExecutorContext", def.context());
     }
 }

--- a/api/src/test/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinitionTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinitionTest.java
@@ -27,11 +27,12 @@ import org.junit.Test;
 
 @ManagedScheduledExecutorDefinition( // from ManagedScheduledExecutorDefinition JavaDoc
         name = "java:comp/concurrent/MyScheduledExecutor",
+        context = "java:comp/concurrent/MyScheduledExecutorContext",
         hungTaskThreshold = 30000,
-        maxAsync = 3,
-        context = @ContextServiceDefinition(
-                  name = "java:comp/concurrent/MyScheduledExecutorContext",
-                  propagated = APPLICATION))
+        maxAsync = 3)
+@ContextServiceDefinition( // from ManagedScheduledExecutorDefinition JavaDoc, used by above
+        name = "java:comp/concurrent/MyScheduledExecutorContext",
+        propagated = APPLICATION)
 @ManagedScheduledExecutorDefinition(
         name = "java:global/concurrent/ManagedScheduledExecutorDefinitionDefaults")
 public class ManagedScheduledExecutorDefinitionTest {
@@ -54,11 +55,7 @@ public class ManagedScheduledExecutorDefinitionTest {
         assertNotNull(def);
         assertEquals(-1, def.hungTaskThreshold());
         assertEquals(-1, def.maxAsync());
-        ContextServiceDefinition csd = def.context();
-        assertEquals("java:comp/DefaultContextService", csd.name());
-        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
-        assertArrayEquals(new String[] {}, csd.unchanged());
-        assertArrayEquals(new String[] { ALL_REMAINING }, csd.propagated());
+        assertEquals("java:comp/DefaultContextService", def.context());
     }
 
     /**
@@ -74,10 +71,6 @@ public class ManagedScheduledExecutorDefinitionTest {
         assertNotNull(def);
         assertEquals(30000, def.hungTaskThreshold());
         assertEquals(3, def.maxAsync());
-        ContextServiceDefinition csd = def.context();
-        assertEquals("java:comp/concurrent/MyScheduledExecutorContext", csd.name());
-        assertArrayEquals(new String[] { APPLICATION }, csd.propagated());
-        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
-        assertArrayEquals(new String[] {}, csd.unchanged());
+        assertEquals("java:comp/concurrent/MyScheduledExecutorContext", def.context());
     }
 }

--- a/api/src/test/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinitionTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinitionTest.java
@@ -27,10 +27,11 @@ import org.junit.Test;
 
 @ManagedThreadFactoryDefinition( // from ManagedThreadFactoryDefinition JavaDoc
         name = "java:global/concurrent/MyThreadFactory",
-        priority = 4,
-        context = @ContextServiceDefinition(
-                  name = "java:global/concurrent/MyThreadFactoryContext",
-                  propagated = APPLICATION))
+        context = "java:global/concurrent/MyThreadFactoryContext",
+        priority = 4)
+@ContextServiceDefinition( // from ManagedThreadFactoryDefinition JavaDoc, used by above
+        name = "java:global/concurrent/MyThreadFactoryContext",
+        propagated = APPLICATION)
 @ManagedThreadFactoryDefinition(
         name = "java:comp/concurrent/ManagedThreadFactoryDefinitionDefaults")
 public class ManagedThreadFactoryDefinitionTest {
@@ -52,11 +53,7 @@ public class ManagedThreadFactoryDefinitionTest {
                 def = anno;
         assertNotNull(def);
         assertEquals(Thread.NORM_PRIORITY, def.priority());
-        ContextServiceDefinition csd = def.context();
-        assertEquals("java:comp/DefaultContextService", csd.name());
-        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
-        assertArrayEquals(new String[] {}, csd.unchanged());
-        assertArrayEquals(new String[] { ALL_REMAINING }, csd.propagated());
+        assertEquals("java:comp/DefaultContextService", def.context());
     }
 
     /**
@@ -71,10 +68,6 @@ public class ManagedThreadFactoryDefinitionTest {
                 def = anno;
         assertNotNull(def);
         assertEquals(4, def.priority());
-        ContextServiceDefinition csd = def.context();
-        assertEquals("java:global/concurrent/MyThreadFactoryContext", csd.name());
-        assertArrayEquals(new String[] { APPLICATION }, csd.propagated());
-        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
-        assertArrayEquals(new String[] {}, csd.unchanged());
+        assertEquals("java:global/concurrent/MyThreadFactoryContext", def.context());
     }
 }

--- a/api/src/test/java/jakarta/enterprise/concurrent/ThreadContextProviderTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ThreadContextProviderTest.java
@@ -31,19 +31,17 @@ import org.junit.Test;
 /**
  * Tests of the ThreadContextProvider examples from the specification and JavaDoc.
  */
-@ManagedExecutorDefinition( // from JavaDoc
-        name = "java:module/concurrent/MyCustomContextExecutor",
-        maxAsync = 3,
-        context = @ContextServiceDefinition(
-                  name = "java:module/concurrent/MyCustomContext",
-                  propagated = ThreadContextProviderTest.CONTEXT_NAME,
-                  cleared = { ContextServiceDefinition.SECURITY, ContextServiceDefinition.TRANSACTION },
-                  unchanged = ContextServiceDefinition.ALL_REMAINING))
+@ContextServiceDefinition( // from JavaDoc
+        name = "java:module/concurrent/MyCustomContext",
+        propagated = ThreadContextProviderTest.CONTEXT_NAME,
+        cleared = { ContextServiceDefinition.SECURITY, ContextServiceDefinition.TRANSACTION },
+        unchanged = ContextServiceDefinition.ALL_REMAINING)
+@ContextServiceDefinition( // from spec ThreadContextProvider example
+        name = "java:module/concurrent/PriorityContext",
+        propagated = "ThreadPriority")
 @ManagedExecutorDefinition( // from spec ThreadContextProvider example
         name = "java:module/concurrent/PriorityExec",
-        context = @ContextServiceDefinition(
-                  name = "java:module/concurrent/PriorityContext",
-                  propagated = "ThreadPriority"))
+        context = "java:module/concurrent/PriorityContext")
 public class ThreadContextProviderTest {
     public static final String CONTEXT_NAME = "MyCustomContext";
 
@@ -103,8 +101,13 @@ public class ThreadContextProviderTest {
         assertNotNull(def);
         assertEquals(-1, def.hungTaskThreshold());
         assertEquals(-1, def.maxAsync());
-        ContextServiceDefinition csd = def.context();
-        assertEquals("java:module/concurrent/PriorityContext", csd.name());
+        assertEquals("java:module/concurrent/PriorityContext", def.context());
+
+        ContextServiceDefinition csd = null;
+        for (ContextServiceDefinition anno : getClass().getAnnotationsByType(ContextServiceDefinition.class))
+            if ("java:module/concurrent/PriorityContext".equals(anno.name()))
+                csd = anno;
+        assertNotNull(csd);
         assertArrayEquals(new String[] { "ThreadPriority" }, csd.propagated());
         assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
         assertArrayEquals(new String[] {}, csd.unchanged());

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -2493,11 +2493,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@ContextServiceDefinition(
+        name = "java:module/concurrent/PriorityContext",
+        propagated = "ThreadPriority")
 @ManagedExecutorDefinition(
         name = "java:module/concurrent/PriorityExec",
-        context = @ContextServiceDefinition(
-                  name = "java:module/concurrent/PriorityContext",
-                  propagated = "ThreadPriority"))
+        context = "java:module/concurrent/PriorityContext")
 public class MyServlet extends HttpServlet {
    @Resource(lookup = "java:module/concurrent/PriorityExec")
    ManagedExecutorService executor;


### PR DESCRIPTION
Resource definition annotations (ManagedExecutorDefinition) should mention the corresponding deployment descriptor element for defining the resource (managed-executor in this case) and mention what happens when both are specified with the same name. For that, we can copy what is being done for the existing DataSourceDefinition/data-source.

Also, we need to correct a bug in how I styled the referencing of ContextServiceDefinition from a ManagedExecutorDefinition/ManagedScheduledExecutorDefinition/ManagedThreadFactoryDefinition.  Originally, I had it nesting a ContextServiceDefinition within the ManagedExecutorDefinition,

```
@ManagedExecutorDefinition(
        name = "java:module/concurrent/MyExecutor",
        context = @ContextServiceDefinition(
                  name = "java:module/concurrent/MyExecutorContext",
                  propagated = { SECURITY, APPLICATION }))
public class ManagedExecutorDefinitionTest {
```

However, the nested `@ContextServiceDefinition` in the above is not being treated as a type level annotation by Java in that `ManagedExecutorDefinitionTest.class.getAnnotationsByType(ContextServiceDefinition.class)` returns empty, so we should probably not be doing this.  Another approach, which also has the advantage of lining up better with the corresponding resource definition entries of the deployment descriptor, is to put both annotations directly on the type itself,

```
@ManagedExecutorDefinition(
        name = "java:module/concurrent/MyExecutor",
        context = "java:module/concurrent/MyExecutorContext")
@ContextServiceDefinition(
        name = "java:module/concurrent/MyExecutorContext",
        propagated = { SECURITY, APPLICATION })
public class ManagedExecutorDefinitionTest {
```

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>