### PR TITLE
NullPointerException when getNextRunTime is null

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ZonedTrigger.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ZonedTrigger.java
@@ -101,7 +101,7 @@ public interface ZonedTrigger extends Trigger {
      */
     public default Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
         ZonedDateTime nextTime = getNextRunTime(lastExecutionInfo, taskScheduledTime.toInstant().atZone(getZoneId()));
-        return Date.from(nextTime.toInstant());
+        return nextTime == null ? null : Date.from(nextTime.toInstant());
     }
 
     /**

--- a/api/src/test/java/jakarta/enterprise/concurrent/ZonedTriggerTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ZonedTriggerTest.java
@@ -238,6 +238,22 @@ public class ZonedTriggerTest {
     }
 
     /**
+     * Ensure that the default method for getNextRunTime(LastExecution, Date) can
+     * cope with a null being returned by getNextRunTime(LastExecution, ZonedDateTime).
+     */
+    @Test
+    public void testNullNextRunTime() {
+        ZonedTrigger trigger = new ZonedTrigger() {
+            @Override
+            public ZonedDateTime getNextRunTime(LastExecution lastExec, ZonedDateTime taskScheduledTime) {
+                return null;
+            }
+        };
+
+        assertNull(trigger.getNextRunTime(null, new Date()));
+    }
+
+    /**
      * Test the default implementation of ZonedTrigger.skipRun(LastExecution, Date),
      * which ought to delegate to skipRun(LastExecution, ZonedDateTime).
      */


### PR DESCRIPTION
The default implementation for getNextRunTime(LastExecution, Date) has a bug when it receives a null back from the getNextRunTime(LastExecution, ZonedDateTime) method which it delegates to.  It needs to be fixed to flow the null back to the caller, where it can be properly interpreted as meaning there is no next execution.

```
Caused by: java.lang.NullPointerException
at jakarta.enterprise.concurrent.ZonedTrigger.getNextRunTime(ZonedTrigger.java:104) 
```

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>