### PR TITLE
Remove dead code from TCK

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionBean.java
@@ -49,12 +49,4 @@ public class ContextServiceDefinitionBean implements ContextServiceDefinitionInt
 	public ContextService getContextC() throws NamingException {
 		return InitialContext.doLookup("java:comp/concurrent/EJBContextC");
 	}
-	
-	/**
-	 * Get java:comp/concurrent/ContextB from the bean.
-	 */
-	@Override
-	public ContextService getContextB() throws NamingException {
-		return InitialContext.doLookup("java:comp/concurrent/ContextB");
-	}
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionInterface.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionInterface.java
@@ -25,9 +25,4 @@ public interface ContextServiceDefinitionInterface {
 	 * Get java:comp/concurrent/EJBContextC from the bean.
 	 */
 	public ContextService getContextC() throws NamingException;
-
-	/**
-	 * Get java:comp/concurrent/ContextB from the bean.
-	 */
-	ContextService getContextB() throws NamingException;
 }


### PR DESCRIPTION
Code for an unreachable test case was found in the Concurrency TCK.  It appears to have been copied from a test of the same name in the web module, probably used as a starting point for writing tests for EJBs.  Other dead code was identified and removed back when those tests were added and this might have been missed in the respect that it was more dead code or missed in that it was never finished and enabled.  At this point, we could either remove the test or correct it in a couple of places and enable it.  I have created pulls for both and the community can choose.  This pull is to remove it. The other one is #200.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>