### PR TITLE
Fix and enable broken copied TCK test

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
@@ -273,6 +273,8 @@ public class ContextPropagationTests extends TestClient {
     public void testContextualSupplier() throws Throwable {
 		URLBuilder requestURL = URLBuilder.get().withBaseURL(contextURL).withPaths("ContextServiceDefinitionServlet").withTestName(testName);
 		runTest(requestURL);
+        requestURL = URLBuilder.get().withBaseURL(ejbContextURL).withPaths("ContextServiceDefinitionFromEJBServlet").withTestName(testName);
+        runTest(requestURL);
     }
 
     /**

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionBean.java
@@ -55,6 +55,6 @@ public class ContextServiceDefinitionBean implements ContextServiceDefinitionInt
 	 */
 	@Override
 	public ContextService getContextB() throws NamingException {
-		return InitialContext.doLookup("java:comp/concurrent/ContextB");
+		return InitialContext.doLookup("java:module/concurrent/ContextB");
 	}
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionFromEJBServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionFromEJBServlet.java
@@ -253,7 +253,7 @@ public class ContextServiceDefinitionFromEJBServlet extends TestServlet {
             assertEquals(results.getKey(), Integer.valueOf(0), 
                     "Third-party context type IntContext must be cleared from async contextual Supplier " +
                     "per java:module/concurrent/ContextB configuration.");
-            assertEquals(results.getValue(), "testContextualSupplier-2", 
+            assertEquals(results.getValue(), "testContextualSupplier-1",
                     "Third-party context type StringContext must be propagated to async contextual Supplier " +
                     "per java:module/concurrent/ContextB configuration.");
         } finally {


### PR DESCRIPTION
Code for an unreachable test case was found in the Concurrency TCK.  It appears to have been copied from a test of the same name in the web module, probably used as a starting point for writing tests for EJBs.  Other dead code was identified and removed back when those tests were added and this might have been missed in the respect that it was more dead code or missed in that it was never finished and enabled.  At this point, we could either remove the test or correct it in a couple of places and enable it.  I have created pulls for both and the community can choose.  This pull is to correct it and enable the test. The other one is #199.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>