### PR TITLE
update hard-coded locations of concurrency repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ more.
 
 The project maintains the following source code repositories
 
- * https://github.com/eclipse-ee4j/concurrency-api
+ * https://github.com/jakartaee/concurrency
  * https://github.com/eclipse-ee4j/concurrency-ri
 
 ## Eclipse Contributor Agreement

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -25,7 +25,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 The project maintains the following source code repositories:
 
- * https://github.com/eclipse-ee4j/concurrency-api
+ * https://github.com/jakartaee/concurrency
  * https://github.com/eclipse-ee4j/concurrency-ri
 
 ## Third-party Content

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -194,7 +194,7 @@ public @interface ContextServiceDefinition {
     static final String APPLICATION = "Application";
 
     // TODO CDI context is the topic of
-    // https://github.com/eclipse-ee4j/concurrency-api/issues/105
+    // https://github.com/jakartaee/concurrency/issues/105
 
     /**
      * <p>Context that controls the credentials that are associated
@@ -224,7 +224,7 @@ public @interface ContextServiceDefinition {
      * propagated context.</p>
      */
     // TODO the last item above is the topic of
-    // https://github.com/eclipse-ee4j/concurrency-api/issues/102
+    // https://github.com/jakartaee/concurrency/issues/102
     // and can be updated accordingly when that capability is added.
     static final String TRANSACTION = "Transaction";
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <name>Jakarta Concurrency</name>
     <description>Jakarta Concurrency Parent</description>
-    <url>https://github.com/eclipse-ee4j/concurrency-api</url>
+    <url>https://github.com/jakartaee/concurrency</url>
 
     <licenses>
         <license>
@@ -48,9 +48,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/concurrency-api.git</connection>
-        <developerConnection>scm:git:git@github.com:eclipse-ee4j/concurrency-api.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/concurrency-api</url>
+        <connection>scm:git:https://github.com/jakartaee/concurrency.git</connection>
+        <developerConnection>scm:git:git@github.com:jakartaee/concurrency.git</developerConnection>
+        <url>https://github.com/jakartaee/concurrency</url>
     </scm>
     
     <developers>

--- a/tck/README.md
+++ b/tck/README.md
@@ -29,7 +29,7 @@ Knowledge of how these frameworks operate and interact will help during the proj
 To build the TCK locally, first clone this repository and then use the Maven install goal to create the API and TCK modules.
 
 ```sh
-git clone git@github.com:eclipse-ee4j/concurrency-api.git
+git clone git@github.com:jakartaee/concurrency.git
 cd concurrency-api
 mvn install
 ```
@@ -286,7 +286,7 @@ In this case use:
 ```
 
 
-For more information about generating the signature test file, and how the test run read: [ee.jakarta.tck.concurrent.framework.signaturetest/README.md](https://github.com/eclipse-ee4j/concurrency-api/blob/master/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/README.md)
+For more information about generating the signature test file, and how the test run read: [ee.jakarta.tck.concurrent.framework.signaturetest/README.md](https://github.com/jakartaee/concurrency/blob/master/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/README.md)
 
 
 ### Advanced Configuration
@@ -334,7 +334,7 @@ mvn clean test
 
 ## Where to File Challenges
 
-To file a challenge against the TCK, open a [new issue](https://github.com/eclipse-ee4j/concurrency-api/issues/new)
+To file a challenge against the TCK, open a [new issue](https://github.com/jakartaee/concurrency/issues/new)
 against the concurrency-api project. Add the `challenge` label,
 and follow all of the process that is defined under the Challenges section of the
 [Jakarta EE TCK Process](https://jakarta.ee/committees/specification/tckprocess/).


### PR DESCRIPTION
Various files have hard-coded links to the old eclipse-ee4j/concurrency-api repository. Update these to point at the new location: jakartaee/concurrency

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>