### PR TITLE
Spec name misspelled and copyright year variable not expanded in generated JavaDoc

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -150,9 +150,9 @@
                     <notimestamp>true</notimestamp>
                     <docfilessubdirs>true</docfilessubdirs>
                     <quiet>true</quiet>
-                    <header><![CDATA[<br>Jakarta Concurreny API v${project.version}]]></header>
+                    <header><![CDATA[<br>Jakarta Concurrency API v${project.version}]]></header>
                     <bottom>
-<![CDATA[Copyright (c) 2020, ${current.year} Eclipse Foundation.
+<![CDATA[Copyright (c) 2020, 2022 Eclipse Foundation.
     Use is subject to
     <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
 ]]>


### PR DESCRIPTION
While updating the pull for the release review with the latest, I noticed the following on generated JavaDoc for the Concurrency API,
```
Jakarta Concurreny API v3.0.0
```
and
```
Copyright (c) 2020, ${current.year} Eclipse Foundation.
```

This pull corrects the above.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>