### PR TITLE
Generated JavaDoc redundantly refers to API 3.0.0 API

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,7 +28,7 @@
     
     <artifactId>jakarta.enterprise.concurrent-api</artifactId>
     
-    <name>Jakarta Concurrency API</name>
+    <name>Jakarta Concurrency</name>
     <description>Jakarta Concurrency API Module</description>
 
     <properties>


### PR DESCRIPTION
It would have been nice to include this under my previous pull, but I hadn't spotted it yet.

Generated JavaDoc is redundant in stating API twice in lots of places, such as these,
```
<title>Overview (Jakarta Concurrency API 3.0.0 API)</title>
```

```
<h1 class="title">Jakarta Concurrency API 3.0.0 API</h1>
```

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>