### PR TITLE
Disable new tests relying on uncertain behavior of getUserPrincipal

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
@@ -88,14 +88,16 @@ public class ContextPropagationTests extends TestClient {
 	
 	@ArquillianResource(ContextServiceDefinitionFromEJBServlet.class)
 	URL ejbContextURL;
-	
-	@Test
+
+	// HttpServletRequest.getUserPrincipal behavior is unclear when accessed from another thread or the current user is changed
+	@Test(enabled = false)
 	public void testSecurityClearedContext() {
 		URLBuilder requestURL = URLBuilder.get().withBaseURL(jspURL).withPaths("jspTests.jsp").withTestName(testName);
 		runTest(requestURL);
 	}
-	
-	@Test
+
+	// HttpServletRequest.getUserPrincipal behavior is unclear when accessed from another thread or the current user is changed
+	@Test(enabled = false)
 	public void testSecurityUnchangedContext() {
 		URLBuilder requestURL = URLBuilder.get().withBaseURL(jspURL).withPaths("jspTests.jsp").withTestName(testName);
 		runTest(requestURL);


### PR DESCRIPTION
As brought up on the mailing list by @aubi the behavior of HttpServletRequest.getUserPrincipal is unclear when running on a different thread or the current user is switched. We cannot have tests that rely on a particular behavior there and so are disabling the 2 tests that were using it because these tests don't do anything else of significance.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>