### PR TITLE
Switch TCK reference guide email to the spec mailing list

### DIFF
--- a/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
@@ -1,6 +1,6 @@
 = Jakarta Concurrency TCK Reference Guide
 :author: Kyle Aure
-:email: kyle.aure@ibm.com
+:email: cu-dev@eclipse.org
 :revnumber: v1.0
 :toc:
 :sectnums:


### PR DESCRIPTION
Make the update requested by @edbratt on the Concurrency mailing list review of the TCK zip,

> I think I would caution against including Kayle's e-mail in the reference guide doc. Perhaps it would be better to suggest feedback be sent to the e-mail list instead ([cu-dev@eclipse.org](mailto:cu-dev@eclipse.org)). Keep the author name, just not the e-mail address.
