### PR TITLE
jakarta.concurrent.version.ga variable not being replaced in TCK artifact

### DIFF
--- a/tck-dist/src/main/artifacts/artifact-install.sh
+++ b/tck-dist/src/main/artifacts/artifact-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## A sample script to install the artifact directory contents into a local maven repository
-VERSION=${jakarta.concurrent.version.ga}
+VERSION=3.0.0
 
 # Parent pom
 mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \


### PR DESCRIPTION
Our developer trying out the TCK from the zip artifact (rather than the maven jar which we had been using to this point) found that `artifact-install.sh` contains an unexpanded variable,

```
VERSION=${jakarta.concurrent.version.ga}
```

I suspect the intent was for the build to replace that.  For now, the quickest solution is to just hard code it.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>