### PR TITLE
Fix TCK documentation on server dependencies

### DIFF
--- a/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
@@ -221,7 +221,7 @@ Each of these Arquillian tests run within the runtime's Servlet container, with 
 === Test Server Dependencies
 
 If the Test Server is running on a separate JVM (recommended), then the Test Server
-will also need access to the Arquillian, TestNG, Signature Test, and the Derby JDBC libraries.
+will also need access to the TestNG, Signature Test, and the Derby JDBC libraries.
 The Test Server dependencies can be copied over during the build phase.
 
 Example starter/pom.xml:
@@ -229,6 +229,13 @@ Example starter/pom.xml:
 [source, xml]
 ----
 include::../starter/pom.xml[tag=testServerDep]
+----
+
+Using the maven command:
+
+[source, sh]
+----
+$ mvn dependency:copy
 ----
 
 === Configure {TCKTestPlatform}

--- a/tck-dist/src/main/starter/pom.xml
+++ b/tck-dist/src/main/starter/pom.xml
@@ -128,35 +128,26 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<version>${maven.dep.plugin.version}</version>
-				<executions>
-					<execution>
-						<id>copy-server-dependencies</id>
-						<phase>package</phase>
-						<goals>
-							<goal>copy-dependencies</goal>
-						</goals>
-						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>org.testng</groupId>
-									<artifactId>testng</artifactId>
-									<version>${testng.version}</version>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.apache.derby</groupId>
-									<artifactId>derby</artifactId>
-									<version>${derby.version}</version>
-								</artifactItem>
-								<dependency>
-									<groupId>org.netbeans.tools</groupId>
-									<artifactId>sigtest-maven-plugin</artifactId>
-									<version>${sigtest.version}</version>
-								</dependency>
-							</artifactItems>
-							<outputDirectory>${application.server.lib}</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>org.testng</groupId>
+							<artifactId>testng</artifactId>
+							<version>${testng.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.apache.derby</groupId>
+							<artifactId>derby</artifactId>
+							<version>${derby.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.netbeans.tools</groupId>
+							<artifactId>sigtest-maven-plugin</artifactId>
+							<version>${sigtest.version}</version>
+						</artifactItem>
+					</artifactItems>
+					<outputDirectory>${application.server.lib}</outputDirectory>
+				</configuration>
 			</plugin>
 			<!-- end::testServerDep[] -->
 			<!-- Compile plugin for any supplemental class files -->


### PR DESCRIPTION
The documentation on the server dependencies was misleading and did not expressly tell users to use a profile for this work.

Instead, let's simplify our instructions by removing the need for a profile, and give instructions on how to copy dependencies using a separate command. 

Also fixing a misplaced `<dependency>` tag