### PR TITLE
Fix managedthreadfactory component context

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedThreadFactory/resourcedef/ManagedThreadFactoryDefinitionOnEJBServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedThreadFactory/resourcedef/ManagedThreadFactoryDefinitionOnEJBServlet.java
@@ -141,7 +141,7 @@ public class ManagedThreadFactoryDefinitionOnEJBServlet extends TestServlet {
             try {
                 allThreadsRunning.countDown();
                 blocker.await(MAX_WAIT_SECONDS * 5, TimeUnit.SECONDS);
-                lookupTaskResult.complete(InitialContext.doLookup("java:comp/concurrent/EJBThreadFactoryB"));
+                lookupTaskResult.complete((ManagedThreadFactory) managedThreadFactoryDefinitionBean.doLookup("java:comp/concurrent/EJBThreadFactoryB"));
             } catch (Throwable x) {
                 lookupTaskResult.completeExceptionally(x);
             }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedThreadFactory/resourcedef/ManagedThreadFactoryDefinitionOnEJBServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedThreadFactory/resourcedef/ManagedThreadFactoryDefinitionOnEJBServlet.java
@@ -143,7 +143,7 @@ public class ManagedThreadFactoryDefinitionOnEJBServlet extends TestServlet {
                 blocker.await(MAX_WAIT_SECONDS * 5, TimeUnit.SECONDS);
                 lookupTaskResult.complete(InitialContext.doLookup("java:comp/concurrent/EJBThreadFactoryB"));
             } catch (Throwable x) {
-                txTaskResult.completeExceptionally(x);
+                lookupTaskResult.completeExceptionally(x);
             }
         };
 


### PR DESCRIPTION
Obvious copy&paste error:
txTaskResult -> lookupTaskResult.completeExceptionally()

Ad java:comp usage: is there any particular reason to use it in this test? I has a specific behavior in web app (equal to module), but EJB-bound in EAR app. If we want to use it, it must be kept EJB-bound, e.g. lookup it in the managedThreadFactoryDefinitionBean. Personally, I would prefer to use java:app as it makes me better sense to define thread factory for whole app.