### PR TITLE
removing duplicate EJB definition classes

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/security/SecurityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/security/SecurityTests.java
@@ -38,7 +38,8 @@ public class SecurityTests extends TestClient {
 	@Deployment(name="SecurityTests", testable=false)
 	public static EnterpriseArchive createDeployment() {
 		WebArchive war = ShrinkWrap.create(WebArchive.class, "security_web.war")
-				.addPackages(true, getFrameworkPackage(), getCommonPackage(), SecurityTests.class.getPackage());
+				.addPackages(true, getFrameworkPackage(), getCommonPackage(), SecurityTests.class.getPackage())
+				.deleteClasses(SecurityTestRemote.class, SecurityTestEjb.class); //SecurityTestEjb and SecurityTestRemote are in the jar;
 		
 		JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "security_ejb.jar")
 				.addClasses(SecurityTestRemote.class, SecurityTestEjb.class);


### PR DESCRIPTION
This is to remove duplicate EJB definition classes from the arquillian deployment configuration