### PR TITLE
FISH-6216-fixing-binding-issue-for-class-duplication

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/security/SecurityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/security/SecurityTests.java
@@ -37,7 +37,8 @@ public class SecurityTests extends TestClient {
 	@Deployment(name="SecurityTests", testable=false)
 	public static EnterpriseArchive createDeployment() {
 		WebArchive war = ShrinkWrap.create(WebArchive.class, "security_web.war")
-				.addPackages(true, getFrameworkPackage(), getCommonPackage(), SecurityTests.class.getPackage());
+				.addPackages(true, getFrameworkPackage(), getCommonPackage(), SecurityTests.class.getPackage())
+				.deleteClasses(SecurityTestRemote.class, SecurityTestEjb.class); //SecurityTestEjb and SecurityTestRemote are in the jar
 		
 		JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "security_ejb.jar")
 				.addClasses(SecurityTestRemote.class, SecurityTestEjb.class);


### PR DESCRIPTION
Removing duplicate classes SecurityTestRemote and SecurityTestEjb from war, because they are already in jar. Same classes cannot be in both archives inside one ear application.
Same as https://github.com/jakartaee/concurrency/pull/218, just different test.

I will follow the challenge process.