### PR TITLE
test dependency issues fixed

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         
-        
+        <!-- Used in TCK only -->
         <testng.version>6.14.3</testng.version>
         <arquillian.version>1.6.0.Final</arquillian.version>
                 
@@ -140,18 +140,6 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <version>${jakarta.cdi.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.testng</groupId>
-            <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
     </dependencyManagement>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -90,13 +90,15 @@
 			<artifactId>jakarta.enterprise.cdi-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.arquillian.testng</groupId>
-			<artifactId>arquillian-testng-container</artifactId>
-		</dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <version>${arquillian.version}</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<resources>


### PR DESCRIPTION
PR for fixing the test dependency issues.

jUnit version updated to 4.13.2 (in the API).
TestNG version kept at it is to be conservative now (but there is a new major version available).
TestNG and Aquillian Test Container dependencies moved to the TCK (without the version declaration, which is kept in the parent), because they need to be a compile dependencies there but not used in other components like the API (and should not there).