### PR TITLE
Fix ContextB application in cleared

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
@@ -259,8 +259,12 @@ public class ContextPropagationTests extends TestClient {
      * A ContextService contextualizes a Function, which can be supplied as a dependent stage action
      * to an unmanaged CompletableFuture. The dependent stage action runs with the thread context of
      * the thread that contextualizes the Function, per the configuration of the ContextServiceDefinition.
+     *
+     * Assertions on results[0] and results[1] are both invalid because treating those two UNCHANGED context types as
+     * though they were CLEARED.
+     * TCK challenge: https://github.com/jakartaee/concurrency/issues/253
      */
-	@Test
+	@Test(enabled = false)
     public void testContextualFunction() throws Throwable {
 		URLBuilder requestURL = URLBuilder.get().withBaseURL(contextURL).withPaths("ContextServiceDefinitionServlet").withTestName(testName);
 		runTest(requestURL);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextPropagationTests.java
@@ -264,7 +264,7 @@ public class ContextPropagationTests extends TestClient {
      * though they were CLEARED.
      * TCK challenge: https://github.com/jakartaee/concurrency/issues/253
      */
-	@Test(enabled = false)
+	@Test
     public void testContextualFunction() throws Throwable {
 		URLBuilder requestURL = URLBuilder.get().withBaseURL(contextURL).withPaths("ContextServiceDefinitionServlet").withTestName(testName);
 		runTest(requestURL);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ContextService/contextPropagate/ContextServiceDefinitionServlet.java
@@ -60,8 +60,8 @@ import jakarta.transaction.UserTransaction;
                           cleared = StringContext.NAME,
                           unchanged = TRANSACTION)
 @ContextServiceDefinition(name = "java:module/concurrent/ContextB",
-                          cleared = TRANSACTION,
-                          unchanged = { APPLICATION, IntContext.NAME },
+                          cleared = {TRANSACTION, APPLICATION},
+                          unchanged = { IntContext.NAME },
                           propagated = ALL_REMAINING)
 @ContextServiceDefinition(name = "java:comp/concurrent/ContextC")
 @WebServlet("/ContextServiceDefinitionServlet")
@@ -407,7 +407,7 @@ public class ContextServiceDefinitionServlet extends TestServlet {
 
         Object[] results = future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS);
         assertTrue(results[0] instanceof NamingException,
-                "Application context must remain unchanged on contextual Function " +
+                "Application context must be cleared on contextual Function " +
                 "per java:module/concurrent/ContextB configuration. Result: " + results[0]);
         assertEquals(results[1], Integer.valueOf(0), 
                 "Third-party context type IntContext must remain unchanged on contextual Function " +

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionTests.java
@@ -100,7 +100,7 @@ public class ManagedExecutorDefinitionTests extends TestClient{
     }
 
         // TCK Accepted Challenge: https://github.com/jakartaee/concurrency/issues/224
-	@Test(enabled = false)
+	@Test
     public void testCompletedFuture() {
     	runTest(baseURL);
     }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
@@ -222,7 +222,7 @@ public class ManagedScheduledExecutorDefinitionServlet extends TestServlet {
 
             try {
                 String result = stage2.join();
-                throw new AssertionError("Application context must be left unchanged per " +
+                throw new AssertionError("Application context must be cleared per " +
                                          "ManagedExecutorDefinition and ContextServiceDefinition config. " +
                                          "Instead, was able to look up " + result);
             } catch (CompletionException x) {

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionTests.java
@@ -96,7 +96,7 @@ public class ManagedScheduledExecutorDefinitionTests extends TestClient {
 		runTest(baseURL);
     }
         // Accepted TCK Challenge: https://github.com/jakartaee/concurrency/issues/224
-	@Test(enabled = false)
+	@Test
     public void testCompletedFutureMSE() {
 		runTest(baseURL);
     }


### PR DESCRIPTION
In the tests, ContextB's APPLICATION is tested to be cleared. This PR changes it from unchanged to cleared and enables all related challenged tests.