### PR TITLE
Add suite file for web and make tck/api versions clear

### DIFF
--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.enterprise.concurrent</groupId>
         <artifactId>jakarta.enterprise.concurrent.parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.enterprise.concurrent-tck-dist</artifactId>
@@ -45,8 +45,7 @@
     </licenses>
 
     <properties>
-        <jakarta.concurrent.version.ga>3.0.1</jakarta.concurrent.version.ga>
-        <jakarta.concurrent.version.dev>${project.version}</jakarta.concurrent.version.dev>
+        <jakarta.concurrent.tck.version>${project.version}</jakarta.concurrent.tck.version>
 
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
@@ -59,12 +58,12 @@
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
-            <version>${jakarta.concurrent.version.ga}</version>
+            <version>${jakarta.concurrent.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent.parent</artifactId>
-            <version>${jakarta.concurrent.version.ga}</version>
+            <version>${jakarta.concurrent.tck.version}</version>
             <type>pom</type>
         </dependency>
     </dependencies>
@@ -103,7 +102,7 @@
                         <configuration>
                             <backend>html5</backend>
                             <outputFile>
-                                ${project.build.directory}/generated-docs/concurrency-tck-reference-guide-${jakarta.concurrent.version.ga}.html
+                                ${project.build.directory}/generated-docs/concurrency-tck-reference-guide-${jakarta.concurrent.tck.version}.html
                             </outputFile>
                         </configuration>
                     </execution>
@@ -116,7 +115,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <outputFile>
-                                ${project.build.directory}/generated-docs/concurrency-tck-reference-guide-${jakarta.concurrent.version.ga}.pdf
+                                ${project.build.directory}/generated-docs/concurrency-tck-reference-guide-${jakarta.concurrent.tck.version}.pdf
                             </outputFile>
                         </configuration>
                     </execution>
@@ -143,31 +142,11 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>
-                            <finalName>concurrency-tck-${jakarta.concurrent.version.ga}</finalName>
+                            <finalName>concurrency-tck-${jakarta.concurrent.tck.version}</finalName>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            <!--
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>copy-dependencies</id>
-              <phase>prepare-package</phase>
-              <goals>
-                <goal>copy-dependencies</goal>
-              </goals>
-              <configuration>
-                <excludeTransitive>true</excludeTransitive>
-                <stripVersion>true</stripVersion>
-                <overWriteReleases>false</overWriteReleases>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        -->
         </plugins>
     </build>
 </project>

--- a/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
@@ -149,12 +149,12 @@ Here we use the term "suite" informally to describe groups of tests required to 
 
 There are two "suites" included in the TCK.  There is a "suite" for the {APIShortName} API portion of the "Jakarta EE Platform" TCK and there is a second suite for the {APIShortName} SPI portion of the "Jakarta EE Platform".
 
-These "suites" are both represented within the single `artifacts/suite.xml` file and are identified by their package names:
+These "suites" are both represented within the single `artifacts/suite.xml` file for the full profile and `artifacts/suite-web.xml` for the web profile, and are identified by their package names:
 
 1. ee.jakarta.tck.concurrent.api.*
 1. ee.jakarta.tck.concurrent.spec.*
 
-*Note:* An implementation **MUST** run against all tests provided in the suite XML file [underline]#unmodified# for an implementation to pass the TCK.
+*Note:* An implementation **MUST** run against all tests provided in the suite XML file for the given profile [underline]#unmodified# for an implementation of such profile to pass the TCK.
 
 ===== API Signature Files
 

--- a/tck-dist/src/main/assembly/assembly.xml
+++ b/tck-dist/src/main/assembly/assembly.xml
@@ -25,7 +25,7 @@
 		<format>zip</format>
 	</formats>
 
-	<baseDirectory>concurrency-tck-${jakarta.concurrent.version.ga}</baseDirectory>
+	<baseDirectory>concurrency-tck-${jakarta.concurrent.tck.version}</baseDirectory>
 
 	<files>
 

--- a/tck-dist/src/main/starter/pom.xml
+++ b/tck-dist/src/main/starter/pom.xml
@@ -46,7 +46,10 @@
         <!-- Location to put test application dependencies -->
         <application.server.lib>[path/to/appserver/lib]</application.server.lib>
 
-        <!-- Pointer to suite.xml file that has the TestNG configuration -->
+        <!-- Pointer to suite.xml file that has the TestNG configuration. 
+             Use suite.xml to test the full profile
+             Use suite-web.xml to test the web profile
+         -->
         <suiteXmlFile>suite.xml</suiteXmlFile>
         
         <!-- Pointer to logging.properties file that has the java.util.logging configuration -->

--- a/tck-dist/src/main/starter/suite-web.xml
+++ b/tck-dist/src/main/starter/suite-web.xml
@@ -18,10 +18,15 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <!-- 
-    This suite file is for testing Jakarta Concurrency against the Jakarta Full Profile.
+    This suite file is for testing Jakarta Concurrency against the Jakarta Web Profile.
  -->
 <suite name="jakarta-concurrency" verbose="2" configfailurepolicy="continue">
     <test name="jakarta-concurrency.tck">
+        <groups>
+            <run>
+                <exclude name="eefull" />
+            </run>
+        </groups>
         <packages>
             <package name="ee.jakarta.tck.concurrent.api.*"/>
             <package name="ee.jakarta.tck.concurrent.spec.*"/>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -44,8 +44,7 @@
     </licenses>
 
     <properties>
-        <jakarta.concurrent.version.ga>3.0.0</jakarta.concurrent.version.ga>
-        <jakarta.concurrent.version.dev>${project.version}</jakarta.concurrent.version.dev>
+        <jakarta.concurrent.api.version>3.0.1</jakarta.concurrent.api.version>
         <sigtest.version>1.6</sigtest.version>
     </properties>
 
@@ -53,7 +52,7 @@
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-            <version>${jakarta.concurrent.version.dev}</version>
+            <version>${jakarta.concurrent.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -194,7 +193,7 @@
                                         <artifactItem>
                                             <groupId>jakarta.enterprise.concurrent</groupId>
                                             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-                                            <version>${jakarta.concurrent.version.ga}</version>
+                                            <version>${jakarta.concurrent.api.version}</version>
                                             <type>jar</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/concurrency-api</outputDirectory>


### PR DESCRIPTION
An extra suite.xml file was added to the starter module to test the
web-profile. The guide was updated to mention this.

Since the API version of Concurrency (e.g. 3.0.1) and the TCK version
(e.g. 3.0.2) don't necessarily have to be the same, the properties for
these were renamed to make it more clear which is which.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>