### PR TITLE
avoid duplicate managed executor definitions

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionTests.java
@@ -64,6 +64,7 @@ public class ManagedExecutorDefinitionTests extends TestClient{
 				.addPackages(false, getFrameworkPackage(), ManagedExecutorDefinitionTests.class.getPackage())
 				.deleteClasses(
 						AppBean.class,
+						ManagedExecutorDefinitionWebBean.class,
 						ManagedExecutorDefinitionServlet.class,
 						ManagedExecutorDefinitionOnEJBServlet.class,
 						ContextServiceDefinitionServlet.class)

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebBean.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * ContextServiceDefinitions are defined under
+ * {@link ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextServiceDefinitionBean}
+ */
+@ManagedExecutorDefinition(name = "java:app/concurrent/EJBExecutorA",
+                           context = "java:app/concurrent/EJBContextA",
+                           maxAsync = 2,
+                           hungTaskThreshold = 300000)
+@ManagedExecutorDefinition(name = "java:comp/concurrent/EJBExecutorC")
+@Local(ManagedExecutorDefinitionInterface.class)
+@Stateless
+public class ManagedExecutorDefinitionWebBean implements ManagedExecutorDefinitionInterface {
+	
+	@Override
+	public Object doLookup(String name) throws NamingException {
+		return InitialContext.doLookup(name);
+	}
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebTests.java
@@ -58,6 +58,7 @@ public class ManagedExecutorDefinitionWebTests extends TestClient{
 						ContextServiceDefinitionInterface.class,
 						ContextServiceDefinitionWebBean.class,
 						ContextServiceDefinitionServlet.class)
+				.deleteClasses(ManagedExecutorDefinitionBean.class)
 				.addAsServiceProvider(ThreadContextProvider.class.getName(), IntContextProvider.class.getName(), StringContextProvider.class.getName());
 		
 		return war;

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionTests.java
@@ -65,13 +65,13 @@ public class ManagedScheduledExecutorDefinitionTests extends TestClient {
 				.addPackages(false, getFrameworkPackage(), ManagedScheduledExecutorDefinitionTests.class.getPackage())
 				.deleteClasses(
 						ReqBean.class,
+						ManagedScheduledExecutorDefinitionWebBean.class,
 						ManagedScheduledExecutorDefinitionServlet.class,
 						ManagedScheduledExecutorDefinitionOnEJBServlet.class)
 				.addClasses(
 						ContextServiceDefinitionInterface.class,
 						ContextServiceDefinitionBean.class)
 				.addAsManifestResource(ManagedScheduledExecutorDefinitionTests.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
-//				TODO document how users can dynamically inject vendor specific deployment descriptors into this archive
 		
 		EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ManagedScheduledExecutorDefinitionTests.ear").addAsModules(war, jar);
 		

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionWebBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionWebBean.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
+import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextServiceDefinitionServlet;
+import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextServiceDefinitionBean;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * @ContextServiceDefinitions are defined under {@link ContextServiceDefinitionServlet} and {@link ContextServiceDefinitionBean}
+ */
+@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/EJBScheduledExecutorA",
+                           context = "java:app/concurrent/EJBContextA",
+                           maxAsync = 3,
+                           hungTaskThreshold = 360000)
+@ManagedScheduledExecutorDefinition(name = "java:comp/concurrent/EJBScheduledExecutorC")
+@Local(ManagedScheduleExecutorDefinitionInterface.class)
+@Stateless
+public class ManagedScheduledExecutorDefinitionWebBean implements ManagedScheduleExecutorDefinitionInterface {
+	
+	@Override
+	public Object doLookup(String name) throws NamingException {
+		return InitialContext.doLookup(name);
+	}
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionWebTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionWebTests.java
@@ -57,7 +57,7 @@ public class ManagedScheduledExecutorDefinitionWebTests extends TestClient {
 						ContextServiceDefinitionServlet.class,
 						ContextServiceDefinitionInterface.class,
 						ContextServiceDefinitionWebBean.class)
-				.addAsWebInfResource(ManagedScheduledExecutorDefinitionWebTests.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml")
+				.deleteClasses(ManagedScheduledExecutorDefinitionBean.class)
 				.addAsServiceProvider(ThreadContextProvider.class.getName(), IntContextProvider.class.getName(), StringContextProvider.class.getName());
 		
 		return war;


### PR DESCRIPTION
# Fixing duplicate ManagedExecutorDefinitions for web profile testing

Fixes #263 
This is required for Web profile testing because in the following packages there are two EJBs that both register the same ManagedExecutorDefinition at the JNDI scope of `java:module` which was missed when originally separating the Full profile and Web profile tests.  In the following sections, I have created lists of the context services and managed executors for these packages to show the updated state of these tests in a way that is easier to understand than the Arquillian packaging alone.

## Package: ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef

### ManagedExecutorDefinitionWebTests (for web profile)

#### WAR archive

```java
@List({
	@ContextServiceDefinition(name = "java:app/concurrent/ContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:module/concurrent/ContextB", cleared = {"Transaction"}, unchanged = {"Application", "IntContext"}, propagated = {"Remaining"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/ContextC")})
class ContextServiceDefinitionServlet

@List({
	@ContextServiceDefinition(name = "java:app/concurrent/EJBContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/EJBContextC")})
class ContextServiceDefinitionWebBean

@List({
	@ManagedExecutorDefinition(name = "java:app/concurrent/ExecutorA", context = "java:app/concurrent/ContextA", maxAsync = 2, hungTaskThreshold = 300000L),
	@ManagedExecutorDefinition(name = "java:module/concurrent/ExecutorB", context = "java:module/concurrent/ContextB", maxAsync = 1),
	@ManagedExecutorDefinition(name = "java:comp/concurrent/ExecutorC")})
class ManagedExecutorDefinitionServlet

@List({
	@ManagedExecutorDefinition(name = "java:app/concurrent/EJBExecutorA", context = "java:app/concurrent/EJBContextA", maxAsync = 2, hungTaskThreshold = 300000L),
	@ManagedExecutorDefinition(name = "java:comp/concurrent/EJBExecutorC")})
class ManagedExecutorDefinitionWebBean
```

### ManagedExecutorDefinitionTests (for full profile)

#### Web Module

```java
@List({
	@ContextServiceDefinition(name = "java:app/concurrent/ContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:module/concurrent/ContextB", cleared = {"Transaction"}, unchanged = {"Application", "IntContext"}, propagated = {"Remaining"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/ContextC")})
class ContextServiceDefinitionServlet

@List({
	@ManagedExecutorDefinition(name = "java:app/concurrent/ExecutorA", context = "java:app/concurrent/ContextA", maxAsync = 2, hungTaskThreshold = 300000L),
	@ManagedExecutorDefinition(name = "java:module/concurrent/ExecutorB", context = "java:module/concurrent/ContextB", maxAsync = 1),
	@ManagedExecutorDefinition(name = "java:comp/concurrent/ExecutorC")})
class ManagedExecutorDefinitionServlet
```

#### Jar Module

```java
@List({
	@ContextServiceDefinition(name = "java:app/concurrent/EJBContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:module/concurrent/ContextB", propagated = {"Application", "StringContext"}, cleared = {"IntContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/EJBContextC")})
class ContextServiceDefinitionBean

@List({
	@ManagedExecutorDefinition(name = "java:app/concurrent/EJBExecutorA", context = "java:app/concurrent/EJBContextA", maxAsync = 2, hungTaskThreshold = 300000L),
	@ManagedExecutorDefinition(name = "java:module/concurrent/ExecutorB", context = "java:module/concurrent/ContextB", maxAsync = 1),
	@ManagedExecutorDefinition(name = "java:comp/concurrent/EJBExecutorC")})
class ManagedExecutorDefinitionBean

```

##  Package: ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef

### ManagedScheduledExecutorDefinitionWebTests (for web profile)

#### WAR archive

```java
@List({
	@ContextServiceDefinition(name = "java:app/concurrent/ContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:module/concurrent/ContextB", cleared = {"Transaction"}, unchanged = {"Application", "IntContext"}, propagated = {"Remaining"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/ContextC")})
class ContextServiceDefinitionServlet

@List({
	@ContextServiceDefinition(name = "java:app/concurrent/EJBContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/EJBContextC")})
class ContextServiceDefinitionWebBean

@List({
	@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/ScheduledExecutorA", context = "java:app/concurrent/ContextA", maxAsync = 3, hungTaskThreshold = 360000L),
	@ManagedScheduledExecutorDefinition(name = "java:module/concurrent/ScheduledExecutorB", context = "java:module/concurrent/ContextB", maxAsync = 4),
	@ManagedScheduledExecutorDefinition(name = "java:comp/concurrent/ScheduledExecutorC")})
class ManagedScheduledExecutorDefinitionServlet

@List({
	@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/EJBScheduledExecutorA", context = "java:app/concurrent/EJBContextA", maxAsync = 3, hungTaskThreshold = 360000L),
	@ManagedScheduledExecutorDefinition(name = "java:comp/concurrent/EJBScheduledExecutorC")})
class ManagedScheduledExecutorDefinitionWebBean
```

### ManagedScheduledExecutorDefinitionTests (for full profile)

#### Web Module

```java
@List({
	@ContextServiceDefinition(name = "java:app/concurrent/ContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:module/concurrent/ContextB", cleared = {"Transaction"}, unchanged = {"Application", "IntContext"}, propagated = {"Remaining"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/ContextC")})
class ContextServiceDefinitionServlet

@List({
	@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/ScheduledExecutorA", context = "java:app/concurrent/ContextA", maxAsync = 3, hungTaskThreshold = 360000L),
	@ManagedScheduledExecutorDefinition(name = "java:module/concurrent/ScheduledExecutorB", context = "java:module/concurrent/ContextB", maxAsync = 4),
	@ManagedScheduledExecutorDefinition(name = "java:comp/concurrent/ScheduledExecutorC")})
class ManagedScheduledExecutorDefinitionServlet
```

#### Jar Module

```java
@List({
	@ContextServiceDefinition(name = "java:app/concurrent/EJBContextA", propagated = {"Application", "IntContext"}, cleared = {"StringContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:module/concurrent/ContextB", propagated = {"Application", "StringContext"}, cleared = {"IntContext"}, unchanged = {"Transaction"}),
	@ContextServiceDefinition(name = "java:comp/concurrent/EJBContextC")})
class ContextServiceDefinitionBean

@List({
	@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/EJBScheduledExecutorA", context = "java:app/concurrent/ContextA", maxAsync = 3, hungTaskThreshold = 360000L),
	@ManagedScheduledExecutorDefinition(name = "java:module/concurrent/ScheduledExecutorB", context = "java:module/concurrent/ContextB", maxAsync = 4),
	@ManagedScheduledExecutorDefinition(name = "java:comp/concurrent/EJBScheduledExecutorC")})
class ManagedScheduledExecutorDefinitionBean
```

## Open Liberty passing these tests
![Screen Shot 2022-08-08 at 2 34 14 PM](https://user-images.githubusercontent.com/33664635/183499581-4c7838ca-caa5-43ab-99c7-48f9a35307c3.png)

