### PR TITLE
Schedule annotation for asynchronous methods

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -178,6 +178,62 @@ public @interface Asynchronous {
      */
     @Nonbinding
     String executor() default "java:comp/DefaultManagedExecutorService";
+
+    /**
+     * <p>Establishes a schedule for repeated execution of the method.
+     * A single future represents the completion of all executions in the schedule.
+     * The Jakarta EE product attempts to run the method at the scheduled times
+     * until its future is completed or the method returns a non-null result value
+     * or raises an exception.</p>
+     *
+     * <p>Computation of the start time for the next execution occurs
+     * after the completion of the current execution. This prevents overlap
+     * of executions from the same asynchronous method request. Scheduled
+     * execution times that overlap a prior execution that is still running
+     * are skipped. For example, if an asynchronous method is scheduled to
+     * run every minute on the minute and execution of the method starts at
+     * 8:00 AM, lasting for 2 minutes and 10 seconds, then the Jakarta EE product
+     * attempts to start the next execution of the method at 8:03 AM.</p>
+     *
+     * <p>Scheduled asynchronous methods are treated similar to other scheduled
+     * tasks in that they are not subject to {@code max-async} constaints of
+     * {@code managed-scheduled-executor-definition} and
+     * {@code managed-executor-definition} and the corresponding
+     * {@link ManagedScheduledExecutorDefinition#maxAsync()} and
+     * {@link ManagedExecutorDefinition#maxAsync()}.</p>
+     *
+     * <p>When a list of multiple {@link Schedule} annotations is specified,
+     * the next execution time is computed according to each, choosing the
+     * closest future time after the current time. This allows composite
+     * schedules such as,
+     * </p>
+     *
+     * <pre>
+     * {@literal @}Asynchronous(runAt = {
+     *     {@literal @}Schedule(daysOfWeek = { DayOfWeek.TUESDAY, DayOfWeek.THURSDAY }, hours = 8),
+     *     {@literal @}Schedule(daysOfweek = DayOfWeek.WEDNESDAY, hours = 10, minutes = 30)
+     * })
+     * public CompletableFuture{@literal <String>} attendLectureAndLab(String course) {
+     *     ...
+     *     if (endOfSemester)
+     *         return Asynchronous.Result.complete(courseRecord);
+     *     else
+     *         return null; // continue at next scheduled time
+     * }
+     *
+     * ...
+     *
+     * student.attendLectureAndLab(courseName).thenApply(this::assignGrade);
+     * </pre>
+     *
+     * <p>The default value of empty array indicates that the task does not
+     * run on a schedule and instead runs one time.</p>
+     *
+     * @return a schedule for the task or an empty array, where the latter indicates
+     *         to run once without a schedule.
+     */
+    @Nonbinding
+    Schedule[] runAt() default {};
 
     /**
      * Mechanism by which the Jakarta EE Product Provider makes available

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -141,7 +141,9 @@ public @interface ManagedExecutorDefinition {
      * not apply to tasks and actions that the executor runs inline,
      * such as when a thread requests
      * {@link java.util.concurrent.CompletableFuture#join()} and the
-     * action runs inline if it has not yet started.</p>
+     * action runs inline if it has not yet started.
+     * This constraint does not apply to tasks that are scheduled
+     * via {@link Asynchronous#runAt()}.</p>
      *
      * <p>The default value of <code>-1</code> indicates unbounded,
      * although still subject to resource constraints of the system.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -143,7 +143,8 @@ public @interface ManagedScheduledExecutorDefinition {
      * {@link java.util.concurrent.CompletableFuture#join()} and the
      * action runs inline if it has not yet started.
      * This constraint also does not apply to tasks that are scheduled
-     * via the <code>schedule*</code> methods.</p>
+     * via the <code>schedule*</code> methods or
+     * {@link Asynchronous#runAt()}.</p>
      *
      * <p>The default value of <code>-1</code> indicates unbounded,
      * although still subject to resource constraints of the system.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/Schedule.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Schedule.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <p>Defines schedules for
+ * {@link Asynchronous#runAt() scheduled asynchronous methods}.</p>
+ *
+ * @since 3.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface Schedule {
+    /**
+     * Cron expression following the rules of {@link CronTrigger}.
+     * When a non-empty value is specified, it overrides all values
+     * that are specified for
+     * month, dayOfMonth, dayOfWeek, hours, minutes, and seconds.
+     * The default value is the empty-string, indicating that
+     * no cron expression is to be used.
+     *
+     * @return cron expression indicating when to run the task.
+     */
+    String cron() default "";
+
+    /**
+     * Months in which the task aims to runs.
+     * The default value is every month.
+     *
+     * @return list of months in which the task aims to run.
+     */
+    Month[] months() default {
+        Month.JANUARY, Month.FEBRUARY, Month.MARCH,
+        Month.APRIL, Month.MAY, Month.JUNE,
+        Month.JULY, Month.AUGUST, Month.SEPTEMBER,
+        Month.OCTOBER, Month.NOVEMBER, Month.DECEMBER };
+
+    /**
+     * Days of the month on which the task aims to runs. Values can range from 1 to 31.
+     * The default value is every day of the month.
+     *
+     * @return list of days of the month on which the task aims to run.
+     */
+    int[] daysOfMonth() default {
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+        31
+    };
+
+    /**
+     * Days of the week on which the task aims to runs.
+     * The default value is every day of the week.
+     *
+     * @return list of days of the month on which the task aims to run.
+     */
+    DayOfWeek[] daysOfWeek() default {
+        DayOfWeek.SUNDAY, DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+        DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY,
+        DayOfWeek.SATURDAY
+    };
+
+    /**
+     * Hours of the day at which the task aims to runs. Values can range from 0 to 23.
+     * The default value is 0 (midnight).
+     *
+     * @return list of hours at which the task aims to run.
+     */
+    int[] hours() default { 0 };
+
+    /**
+     * Minutes at which the task aims to runs. Values can range from 0 to 59.
+     * The default value is 0 (at the start of the hour).
+     *
+     * @return list of minutes at which the task aims to run.
+     */
+    int[] minutes() default { 0 };
+
+    /**
+     * Seconds at which the task aims to runs. Values can range from 0 to 59.
+     * The default value is 0 (at the start of the minute).
+     *
+     * @return list of seconds at which the task aims to run.
+     */
+    int[] seconds() default { 0 };
+
+    /**
+     * Seconds after which an execution that is late to start should be skipped
+     * rather than starting it late. Values must be greater than 0.
+     * The default value is 600 seconds (10 minutes).
+     * This differs from executions that are missed due to overlap, which are always skipped.
+     *
+     * @return the threshold for skipping executions that are late to start.
+     */
+    long skipIfLateBy() default 600L;
+
+    /**
+     * Time zone id, such as America/Chicago or America/Los_Angeles,
+     * which identifies the time zone of the schedule.
+     * The default value of empty string indicates to use the
+     * {@link java.time.ZoneId#systemDefault() default time zone}
+     * for the system.
+     */
+    String zone() default "";
+}

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1,7 +1,7 @@
 :sectnums:
 = Jakarta Concurrency Specification, Version 3.0
 
-Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 
@@ -2523,7 +2523,7 @@ CDI managed bean method to run asynchronously. The CDI managed bean must
 not be a Jakarta Enterprise Bean, and neither the method nor its class
 can be annotated with the MicroProfile Asynchronous annotation.
 
-Each asynchronous method execution corresponds to a managed
+Each invocation of an asynchronous method by the user corresponds to a managed
 `java.util.concurrent.CompletableFuture` instance that is backed by a
 `jakarta.enterprise.concurrent.ManagedExecutorService` as its default
 asynchronous execution facility. Its dependent stages
@@ -2533,6 +2533,17 @@ which also manages the propagation of context to completion stage actions.
 Application code, including from within the asynchronous method, can query
 the status of the completable future instance and can choose to complete
 it at any time and by any means.
+
+==== Scheduled Asynchronous Methods
+
+The `runAt` attribute of `Asynchronous` allows schedules to be assigned
+to asynchronous methods, such that the
+`java.util.concurrent.CompletableFuture` for the asynchronous method
+represents the completion of all executions in the schedule.
+With each execution, the method indicates that subsequent executions are
+needed by returning a `null` result value. The Jakarta EE Product attempts
+to run the method at its scheduled times until its future is completed
+or the method returns a non-null result value or raises an exception.
 
 ==== Application Component Provider’s Responsibilities
 
@@ -2639,7 +2650,8 @@ implementation by means of the
 Provider completes this instance upon completion of the completion stage
 that is returned by the asynchronous method implementation, which is a
 no-op when the asynchronous method implementation chooses to return the
-same instance. If the asynchronous method return type is `void` or if the
+same instance. If the asynchronous method return type is `void`
+and the asynchronous method does not have a schedule, or if the
 asynchronous method implementation raises an error or exception, the
 Jakarta EE Product Provider completes this instance upon return from the
 asynchronous method implementation. The Jakarta EE Product Provider


### PR DESCRIPTION
This corresponds to one of the proposals in #98 - allowing `@Schedule` on an optional attribute of our existing `@Asynchronous`.  This pattern will encourage the chaining of dependent actions to the completion of the schedule rather than code that waits for a ScheduledFuture to complete.

fixes #98
