### PR TITLE
Fix branch name in concurrency CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,20 +5,20 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master" ] #TODO change to main
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ] #TODO change to main
+    branches: [ "main" ]
 
 permissions:
   contents: read
 
 jobs:
   build:
+    strategy:
+      matrix:
+        java-version: [ '17', '21-ea' ]
 
     runs-on: ubuntu-latest
-
-    matrix:
-      java-version: [ '17', '21-ea' ]
 
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
The main branch was re-named after the CI file was created. 
Fixing the branch name. 