### PR TITLE
Update dependabot and CI build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,23 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: maven
+    directory: /api/
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: maven
+    directory: /specification/
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: maven
+    directory: /tck/
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: maven
+    directory: /tck-dist/
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,9 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
+    - name: Build API and TCK
       run: mvn -B package --file pom.xml
+    - name: Build SPEC
+      run: mvn -B package --file specification/pom.xml
+    - name: Build TCK-DIST
+      run: mvn -B package --file tck-dist/pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build API and TCK
-      run: mvn -B package --file pom.xml
+      run: mvn -B install --file pom.xml
     - name: Build SPEC
       run: mvn -B package --file specification/pom.xml
     - name: Build TCK-DIST

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -184,7 +184,7 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -232,7 +232,6 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                         <goals>
                             <goal>jxr</goal>
                         </goals>
-                        <phase>validate</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -240,8 +239,9 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.3.0</version>
                 <configuration>
+                    <source>17</source>
                     <outputDirectory>${project.build.directory}/checkstyle</outputDirectory>
                     <outputFile>${project.build.directory}/checkstyle/checkstyle-result.xml</outputFile>
                     <configLocation>etc/config/checkstyle.xml</configLocation>
@@ -252,7 +252,6 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                         <goals>
                             <goal>checkstyle</goal>
                         </goals>
-                        <phase>validate</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <!-- TODO update for Jakarta 11 -->
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <jakarta.ejb.version>4.0.1</jakarta.ejb.version>
-        <jakarta.jsp.version>3.1.0</jakarta.jsp.version>
+        <jakarta.jsp.version>3.1.1</jakarta.jsp.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <jakarta.interceptor.version>2.1.0</jakarta.interceptor.version>
         <jakarta.cdi.version>4.0.1</jakarta.cdi.version>
@@ -126,7 +126,7 @@
 
     <build>
         <plugins>
-            <!-- Sets minimal Maven version to 3.6.0 -->
+            <!-- Sets minimal Maven version to 3.8.0 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,10 +48,8 @@
         <jakarta.concurrent.tck.version>${project.version}</jakarta.concurrent.tck.version>
 
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctor-maven.version>2.2.4</asciidoctor-maven.version>
+        <asciidoctorj-pdf.version>2.3.7</asciidoctorj-pdf.version>
     </properties>
 
     <dependencies>
@@ -74,22 +72,12 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>${asciidoctor.maven.plugin.version}</version>
+                <version>${asciidoctor-maven.version}</version>
                 <dependencies>
-                    <dependency>
-                        <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
-                        <version>${jruby.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj</artifactId>
-                        <version>${asciidoctorj.version}</version>
-                    </dependency>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>${asciidoctorj.pdf.version}</version>
+                        <version>${asciidoctorj-pdf.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -121,8 +109,10 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <toc>left</toc>
+                    <sourceDirectory>src/main/asciidoc</sourceDirectory>
                     <sourceDocumentName>concurrency-tck-reference-guide.adoc</sourceDocumentName>
+                    <embedAssets>true</embedAssets>
+                    <toc>left</toc>
                     <sourceHighlighter>coderay</sourceHighlighter>
                     <skip>${maven.adoc.skip}</skip>
                 </configuration>

--- a/tck-dist/src/main/assembly/assembly.xml
+++ b/tck-dist/src/main/assembly/assembly.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,83 +17,88 @@
  */
 -->
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 
-	<id>dist</id>
-	<formats>
-		<format>zip</format>
-	</formats>
+    <id>dist</id>
+    <formats>
+        <format>zip</format>
+    </formats>
 
-	<baseDirectory>concurrency-tck-${jakarta.concurrent.tck.version}</baseDirectory>
+    <baseDirectory>concurrency-tck-${jakarta.concurrent.tck.version}
+    </baseDirectory>
 
-	<files>
+    <files>
 
-		<!-- This is the final EFTL license -->
-		<file>
-			<source>src/main/EFTL.txt</source>
-			<destName>LICENSE</destName>
-		</file>
+        <!-- This is the final EFTL license -->
+        <file>
+            <source>src/main/EFTL.txt</source>
+            <destName>LICENSE</destName>
+        </file>
 
-		<!-- The readme included in the distribution zip -->
-		<file>
-			<source>src/main/readme/README.md</source>
-			<destName>README.md</destName>
-		</file>
-		
-		<!-- Signature file -->
-		<file>
-			<source>${project.parent.basedir}/tck/src/main/resources/ee/jakarta/tck/concurrent/spec/signature/jakarta.enterprise.concurrent.sig
-			</source>
-			<outputDirectory>/artifacts</outputDirectory>
-		</file>
-	</files>
+        <!-- The readme included in the distribution zip -->
+        <file>
+            <source>src/main/readme/README.md</source>
+            <destName>README.md</destName>
+        </file>
 
-	<fileSets>
-		<!-- The artifacts -->
-		<fileSet>
-			<directory>src/main/artifacts/</directory>
-			<outputDirectory>/artifacts</outputDirectory>
-			<includes>
-				<include>**/*.sh</include>
-				<include>**/*.txt</include>
-			</includes>
-		</fileSet>
-		<!-- The docs -->
-		<fileSet>
-			<directory>target/generated-docs</directory>
-			<outputDirectory>/docs</outputDirectory>
-			<includes>
-				<include>**/*.html</include>
-				<include>**/*.pdf</include>
-			</includes>
-		</fileSet>
-		<!-- The starter -->
-		<fileSet>
-			<directory>src/main/starter/</directory>
-			<outputDirectory>/starter</outputDirectory>
-			<includes>
-				<include>**/*.xml</include>
-				<include>**/*.properties</include>
-			</includes>
-		</fileSet>
-	</fileSets>
+    </files>
+
+    <fileSets>
+        <!-- The artifacts -->
+        <fileSet>
+            <directory>src/main/artifacts/</directory>
+            <outputDirectory>/artifacts</outputDirectory>
+            <includes>
+                <include>**/*.sh</include>
+                <include>**/*.txt</include>
+            </includes>
+        </fileSet>
+        <!-- The docs -->
+        <fileSet>
+            <directory>target/generated-docs</directory>
+            <outputDirectory>/docs</outputDirectory>
+            <includes>
+                <include>**/*.html</include>
+                <include>**/*.pdf</include>
+            </includes>
+        </fileSet>
+        <!-- The starter -->
+        <fileSet>
+            <directory>src/main/starter/</directory>
+            <outputDirectory>/starter</outputDirectory>
+            <includes>
+                <include>**/*.xml</include>
+                <include>**/*.properties</include>
+            </includes>
+        </fileSet>
+
+        <!-- Signature file(s) -->
+        <fileSet>
+            <directory>${project.parent.basedir}/tck/src/main/resources/ee/jakarta/tck/concurrent/common/signature/
+            </directory>
+            <outputDirectory>/artifacts</outputDirectory>
+            <includes>
+                <include>**/*.sig*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
 
 
-	<dependencySets>
-		<dependencySet>
-			<includes>
-				<include>jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-tck
-				</include>
-				<include>jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-tck:jar:sources
-				</include>
-				<include>jakarta.enterprise.concurrent:jakarta.enterprise.concurrent.parent
-				</include>
-			</includes>
-			<useTransitiveDependencies>true</useTransitiveDependencies>
-			<outputDirectory>artifacts</outputDirectory>
-			<useProjectArtifact>false</useProjectArtifact>
-		</dependencySet>
-	</dependencySets>
+    <dependencySets>
+        <dependencySet>
+            <includes>
+                <include>jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-tck
+                </include>
+                <include>jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-tck:jar:sources
+                </include>
+                <include>jakarta.enterprise.concurrent:jakarta.enterprise.concurrent.parent
+                </include>
+            </includes>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <outputDirectory>artifacts</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
+    </dependencySets>
 
 </assembly>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
Fixes #285 #297 #298 from dependabot

Also fixes some build breaks that were not caught by the CI build. 
- Updated CI build to build the SPEC and TCK-DIST modules
- Fixed TCK-DIST that didn't know about the new signature files