### PR TITLE
Dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-
-  - package-ecosystem: maven
-    directory: /api/
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: maven
-    directory: /specification/
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: maven
-    directory: /tck/
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: maven
-    directory: /tck-dist/
-    schedule:
-      interval: weekly

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -51,7 +51,10 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.10</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <!-- jruby 9.4.3.0 is not working, keeping this on the 9.3.x stream since 9.4 seems to implement a newer ruby version
+        which is causing issues with asciidoctor, even though asciidoctorj considers it compatible.
+        Looks like this may work with the asciidoctorj 3.0.0 stream when it releases-->
+        <jruby.version>9.3.10.0</jruby.version> 
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>


### PR DESCRIPTION
- Manual update to jruby dependency, since the latest is incompatible
- Removing the submodules from the dependabot.yml, since I believe this is causing duplicate PRs to be opened, and dependabot should scan submodules automatically.