### PR TITLE
Correcting links to adoc format in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,9 +4,9 @@
 == Introduction
 
 Jakarta Concurrency provides a specification document, API and TCK for using concurrency from application components without compromising container integrity while still preserving the Jakarta EE platform's fundamental benefits.
-The EE4J project that implements this api is also on [GitHub](https://github.com/eclipse-ee4j/concurrency-ri).
+The EE4J project that implements this api is also on link:https://github.com/eclipse-ee4j/concurrency-ri[GitHub].
 
-This project is part of the overall Jakarta EE platform and is a project within the Eclipse EE4J Project. Please see the [Eclipse EE4J Project](https://projects.eclipse.org/projects/ee4j) for details of the Top Level project.
+This project is part of the overall Jakarta EE platform and is a project within the Eclipse EE4J Project. Please see the link:https://projects.eclipse.org/projects/ee4j[Eclipse EE4J Project] for details of the Top Level project.
 
 
 == Code of Conduct
@@ -18,7 +18,7 @@ This project is governed by the Eclipse Foundation Community Code of Conduct. By
 Having trouble with Jakarta Concurrency? We'd love to help!
 Report bugs with Jakarta Concurrency at https://github.com/jakartaee/concurrency/issues
 
-Besides, we have a [mailing list](https://accounts.eclipse.org/mailing-list/cu-dev) for discussions.
+We also have a link:https://accounts.eclipse.org/mailing-list/cu-dev[mailing list] for discussions.
 
 == Building from Source
 
@@ -26,4 +26,4 @@ You don’t need to build from source to use the project, but you can do so with
 
     mvn clean install
 
-We have a [Jenkins Instance](https://ci.eclipse.org/cu/) set up for building and testing.
+We have a link:https://ci.eclipse.org/cu/[Jenkins Instance] set up for building and testing.


### PR DESCRIPTION
When the README was switched from Markdown to AsciiDoc the links were not switched to the AsciiDoc format, this pr changes the links to AsciiDoc format.