### PR TITLE
Adding github actions to dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
   - package-ecosystem: maven
     directory: /
     schedule:


### PR DESCRIPTION
Since we're using GH Actions on PRs, we should include that in our dependabot scanning.