### PR TITLE
concurrency resources via @Inject and with qualifiers

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -25,7 +25,10 @@ import java.lang.annotation.Target;
 
 /**
  * <p>Defines a {@link ContextService}
- * to be registered in JNDI by the container
+ * to be injected into
+ * {@link ContextService} injection points
+ * with the specified {@link #qualifiers()}
+ * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>
  *
@@ -39,9 +42,19 @@ import java.lang.annotation.Target;
  *     unchanged = TRANSACTION,
  *     cleared = ALL_REMAINING)
  * public class MyServlet extends HttpServlet {
- *    {@literal @}Resource(lookup = "java:app/concurrent/MyContext",
+ *     {@literal @}Inject
+ *     {@literal @}MyQualifier
+ *     ConetxtService appContextSvc1;
+ *
+ *     {@literal @}Resource(lookup = "java:app/concurrent/MyContext",
  *               name = "java:app/concurrent/env/MyContextRef")
- *     ContextService appContextSvc;
+ *     ContextService appContextSvc2;
+ *     ...
+ *
+ * {@literal @}Qualifier
+ * {@literal @}Retention(RetentionPolicy.RUNTIME)
+ * {@literal @}Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+ * public {@literal @}interface MyQualifier {}
  * </pre>
  *
  * <p>Resource environment references in a deployment descriptor
@@ -111,6 +124,28 @@ public @interface ContextServiceDefinition {
      * @return <code>ContextService</code> JNDI name.
      */
     String name();
+
+    /**
+     * <p>List of {@link Qualifier qualifier annotations}.</p>
+     *
+     * <p>A {@link ContextService} injection point
+     * with these qualifier annotations injects a bean that is
+     * produced by this {@code ContextServiceDefinition}.</p>
+     *
+     * <p>The default value is an empty list, indicating that this
+     * {@code ContextServiceDefinition} does not automatically produce
+     * bean instances for any injection points.</p>
+     *
+     * <p>Applications can define their own {@link Producer Producers}
+     * for {@link ContextService} injection points as long as the
+     * qualifier annotations on the producer do not conflict with the
+     * non-empty {@link #qualifiers()} list of a
+     * {@code ContextServiceDefinition}.</p>
+     *
+     * @return list of qualifiers.
+     * @since 3.1
+     */
+    Class<?>[] qualifiers() default {};
 
     /**
      * <p>Types of context to clear whenever a thread runs the

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -25,7 +25,10 @@ import java.lang.annotation.Target;
 
 /**
  * <p>Defines a {@link ManagedScheduledExecutorService}
- * to be registered in JNDI by the container
+ * to be injected into
+ * {@link ManagedScheduledExecutorService} injection points
+ * with the specified {@link #qualifiers()}
+ * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>
  *
@@ -42,10 +45,20 @@ import java.lang.annotation.Target;
  * {@literal @}ContextServiceDefinition(
  *     name = "java:comp/concurrent/MyScheduledExecutorContext",
  *     propagated = APPLICATION)
- *  public class MyServlet extends HttpServlet {
- *    {@literal @}Resource(lookup = "java:comp/concurrent/MyScheduledExecutor",
+ * public class MyServlet extends HttpServlet {
+ *     {@literal @}Inject
+ *     {@literal @}MyQualifier
+ *     ManagedScheduledExecutorService myScheduledExecutor1;
+ *
+ *     {@literal @}Resource(lookup = "java:comp/concurrent/MyScheduledExecutor",
  *               name = "java:comp/concurrent/env/MyScheduledExecutorRef")
- *     ManagedScheduledExecutorService myScheduledExecutor;
+ *     ManagedScheduledExecutorService myScheduledExecutor2;
+ *     ...
+ *
+ * {@literal @}Qualifier
+ * {@literal @}Retention(RetentionPolicy.RUNTIME)
+ * {@literal @}Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+ * public {@literal @}interface MyQualifier {}
  * </pre>
  *
  * <p>Resource environment references in a deployment descriptor
@@ -98,6 +111,28 @@ public @interface ManagedScheduledExecutorDefinition {
      * @return <code>ManagedScheduledExecutorService</code> JNDI name.
      */
     String name();
+
+    /**
+     * <p>List of {@link Qualifier qualifier annotations}.</p>
+     *
+     * <p>A {@link ManagedScheduledExecutorService} injection point
+     * with these qualifier annotations injects a bean that is
+     * produced by this {@code ManagedScheduledExecutorDefinition}.</p>
+     *
+     * <p>The default value is an empty list, indicating that this
+     * {@code ManagedScheduledExecutorDefinition} does not automatically produce
+     * bean instances for any injection points.</p>
+     *
+     * <p>Applications can define their own {@link Producer Producers}
+     * for {@link ManagedScheduledExecutorService} injection points as long as the
+     * qualifier annotations on the producer do not conflict with the
+     * non-empty {@link #qualifiers()} list of a
+     * {@code ManagedScheduledExecutorDefinition}.</p>
+     *
+     * @return list of qualifiers.
+     * @since 3.1
+     */
+    Class<?>[] qualifiers() default {};
 
     /**
      * The name of a {@link ContextService} instance which

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -24,8 +24,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <p>Defines a {@link ManagedThreadFactory}
- * to be registered in JNDI by the container
+ * <p>Defines {@link ManagedThreadFactory} instances
+ * to be injected into
+ * {@link ManagedThreadFactory} injection points
+ * with the specified {@link #qualifiers()}
+ * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>
  *
@@ -41,10 +44,20 @@ import java.lang.annotation.Target;
  * {@literal @}ContextServiceDefinition(
  *     name = "java:global/concurrent/MyThreadFactoryContext",
  *     propagated = APPLICATION)
- *  public class MyServlet extends HttpServlet {
- *    {@literal @}Resource(lookup = "java:global/concurrent/MyThreadFactory",
+ * public class MyServlet extends HttpServlet {
+ *     {@literal @}Inject
+ *     {@literal @}MyQualifier
+ *     ManagedThreadFactory myThreadFactory1;
+ *
+ *     {@literal @}Resource(lookup = "java:global/concurrent/MyThreadFactory",
  *               name = "java:module/concurrent/env/MyThreadFactoryRef")
- *     ManagedThreadFactory myThreadFactory;
+ *     ManagedThreadFactory myThreadFactory2;
+ *     ...
+ *
+ * {@literal @}Qualifier
+ * {@literal @}Retention(RetentionPolicy.RUNTIME)
+ * {@literal @}Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+ * public {@literal @}interface MyQualifier {}
  * </pre>
  *
  * <p>Resource environment references in a deployment descriptor
@@ -96,6 +109,28 @@ public @interface ManagedThreadFactoryDefinition {
      * @return <code>ManagedThreadFactory</code> JNDI name.
      */
     String name();
+
+    /**
+     * <p>List of {@link Qualifier qualifier annotations}.</p>
+     *
+     * <p>A {@link ManagedThreadFactory} injection point
+     * with these qualifier annotations injects a bean that is
+     * produced by this {@code ManagedThreadFactoryDefinition}.</p>
+     *
+     * <p>The default value is an empty list, indicating that this
+     * {@code ManagedThreadFactoryDefinition} does not automatically produce
+     * bean instances for any injection points.</p>
+     *
+     * <p>Applications can define their own {@link Producer Producers}
+     * for {@link ManagedThreadFactory} injection points as long as the
+     * qualifier annotations on the producer do not conflict with the
+     * non-empty {@link #qualifiers()} list of a
+     * {@code ManagedThreadFactoryDefinition}.</p>
+     *
+     * @return list of qualifiers.
+     * @since 3.1
+     */
+    Class<?>[] qualifiers() default {};
 
     /**
      * Determines how context is applied to threads from this

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1,7 +1,7 @@
 :sectnums:
-= Jakarta Concurrency Specification, Version 3.0
+= Jakarta Concurrency Specification, Version 3.1
 
-Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 
@@ -58,6 +58,7 @@ The following Java Platform and Jakarta specifications are referenced in this
 document:
 
 * Concurrency Utilities Specification (JSR-166)
+* Jakarta Contexts and Dependency Injection
 * Jakarta Connectors
 * Java Platform Standard Edition
 * Jakarta Management
@@ -341,7 +342,16 @@ application components to run tasks asynchronously.
 Application Component Providers (application developers) (EE2.11.2) use
 a ManagedExecutorService instance and associated interfaces to develop
 application components that utilize the concurrency functions that these
-interfaces provide. Instances for these objects are retrieved using the
+interfaces provide.
+
+The application uses the
+`jakarta.enterprise.concurrent.ManagedExecutorDefinition` annotation
+to define instances of `ManagedExecutorService` and enumerate the
+qualifiers for `ManagedExecutorService` injection points
+that are to receive a `ManagedExecutorService` bean
+that is produced by the `ManagedExecutorDefinition`.
+
+Applications can also retrieve instances using the
 Java Naming and Directory Interface (JNDI) Naming Context (EE.5) or
 through injection of resource environment references (EE.5.8.1.1).
 
@@ -869,6 +879,12 @@ be propagated by this default `ManagedExecutorService` from a
 contextualizing application component must include naming context,
 classloader, and security information.
 
+The Jakarta EE Product Provider must inject the default
+`ManagedExecutorService` into injection points of
+`ManagedExecutorService` that do not have any qualifiers
+except for where the application provides the producer,
+in which case the application's producer takes precedence.
+
 ==== System Administrator’s Responsibilities 
 
 The System Administrator (EE.2.11.5) is responsible for monitoring and
@@ -1042,7 +1058,16 @@ provides with the addition of `Trigger` and `ManagedTaskListener`.
 Application Component Providers (application developers) (EE2.11.2) use
 a `ManagedScheduledExecutorService` instance and associated interfaces to
 develop application components that utilize the concurrency functions
-that these interfaces provide. Instances for these objects are retrieved
+that these interfaces provide.
+
+The application uses the
+`jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition` annotation
+to define instances of `ManagedScheduledExecutorService` and enumerate the
+qualifiers for `ManagedScheduledExecutorService` injection points
+that are to receive a `ManagedScheduledExecutorService` bean
+that is produced by the `ManagedScheduledExecutorDefinition`.
+
+Applications can also retrieve instances
 using the Java Naming and Directory Interface (JNDI) Naming Context
 (EE.5.2) or through injection of resource environment references
 (EE.5.8.1.1).
@@ -1334,6 +1359,12 @@ types of contexts to be propagated by this default
 component must include naming context, class loader, and security
 information.
 
+The Jakarta EE Product Provider must inject the default
+`ManagedScheduledExecutorService` into injection points of
+`ManagedScheduledExecutorService` that do not have any qualifiers
+except for where the application provides the producer,
+in which case the application's producer takes precedence.
+
 ==== System Administrator’s Responsibilities 
 
 The System Administrator (EE.2.110.5) is responsible for monitoring and
@@ -1481,8 +1512,17 @@ provider's undefined thread context.).
 ==== Application Component Provider’s Responsibilities 
 
 Application Component Providers (application developers) (EE2.11.2) use
-a ContextService instance to create contextual object proxies. Instances
-for these objects are retrieved using the Java Naming and Directory
+a ContextService instance to create contextual object proxies.
+
+The application uses the
+`jakarta.enterprise.concurrent.ContextServiceDefinition` annotation
+to define instances of `ContextService` and enumerate the
+qualifiers for `ContextService` injection points
+that are to receive a `ContextService` bean
+that is produced by the `ContextServiceDefinition`.
+
+Applications can also
+retrieve instances using the Java Naming and Directory
 Interface (JNDI) Naming Context (EE.5) or through injection of resource
 environment references (EE.5.8.1.1).
 
@@ -1851,6 +1891,12 @@ by this default `ContextService` from a contextualizing application
 component must include naming context, class loader, and security
 information.
 
+The Jakarta EE Product Provider must inject the default
+`ContextService` into injection points of
+`ContextService` that do not have any qualifiers
+except for where the application provides the producer,
+in which case the application's producer takes precedence.
+
 ==== Transaction Management 
 
 Contextual dynamic proxies support user-managed global transaction
@@ -1928,7 +1974,16 @@ thread.
 
 Application Component Providers (application developers) (EE2.11.2) use
 a `jakarta.enterprise.concurrent.ManagedThreadFactory` instance to create
-manageable threads. `ManagedThreadFactory` instances are retrieved using
+manageable threads.
+
+The application uses the
+`jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition` annotation
+to define instances of `ManagedThreadFactory` and enumerate the
+qualifiers for `ManagedThreadFactory` injection points
+that are to receive a `ManagedThreadFactory` bean
+that is produced by the `ManagedThreadFactoryDefinition`.
+
+Applications can also retrieve instances using
 the Java Naming and Directory Interface (JNDI) Naming Context (EE.5) or
 through injection of resource environment references (EE.5.8.1.1).
 
@@ -2236,6 +2291,12 @@ name `java:comp/DefaultManagedThreadFactory`. The types of contexts to be
 propagated by this default `ManagedThreadFactory` from a contextualizing
 application component must include naming context, class loader, and
 security information.
+
+The Jakarta EE Product Provider must inject an instance of the
+default `ManagedThreadFactory` into injection points of
+`ManagedThreadFactory` that do not have any qualifiers
+except for where the application provides the producer,
+in which case the application's producer takes precedence.
 
 ==== System Administrator’s Responsibilities 
 


### PR DESCRIPTION
fixes #229

This pull adds to the specification the ability to use `@Inject` to obtain the default instances of ManagedExecutorService, ManagedScheduledExecutorService, ContextService, and ManagedThreadFactory.

It also adds the ability to optionally include qualifiers on the resource definition annotations (ManagedExecutorDefinition, ManagedScheduledExecutorDefinition, ContextServiceDefinition, and ManagedThreadFactoryDefinition, in which case resources produced by them are injectable with the qualifiers.