### PR TITLE
hint to request virtual threads

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -153,6 +153,32 @@ public @interface ManagedExecutorDefinition {
     int maxAsync() default -1;
 
     /**
+     * <p>Indicates whether this executor is requested to
+     * create {@link Thread#isVirtual() virtual} threads
+     * for tasks that do not run inline.</p>
+     *
+     * <p>When {@code true}, the executor can create
+     * virtual threads if it is capable of doing so
+     * and if the request is not overridden by vendor-specific
+     * configuration that restricts the use of virtual threads.</p>
+     *
+     * <p>The default is {@code false}, indicating that the
+     * executor must not create virtual threads.</p>
+     *
+     * <p>It should be noted that some tasks, such as
+     * completion stage actions, can run inline on an existing
+     * thread in response to events such as the completion of
+     * another stage or a join operation on the completion stage.
+     * In situations such as these, the executor does not control
+     * the type of thread that is used to run the task.</p>
+     *
+     * @return {@code true} if the executor can create virtual threads,
+     *         otherwise {@code false}.
+     * @since 3.1
+     */
+    boolean virtual() default false;
+
+    /**
      * Enables multiple <code>ManagedExecutorDefinition</code>
      * annotations on the same type.
      */

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -154,6 +154,32 @@ public @interface ManagedScheduledExecutorDefinition {
     int maxAsync() default -1;
 
     /**
+     * <p>Indicates whether this executor is requested to
+     * create {@link Thread#isVirtual() virtual} threads
+     * for tasks that do not run inline.</p>
+     *
+     * <p>When {@code true}, the executor can create
+     * virtual threads if it is capable of doing so
+     * and if the request is not overridden by vendor-specific
+     * configuration that restricts the use of virtual threads.</p>
+     *
+     * <p>The default is {@code false}, indicating that the
+     * executor must not create virtual threads.</p>
+     *
+     * <p>It should be noted that some tasks, such as
+     * completion stage actions, can run inline on an existing
+     * thread in response to events such as the completion of
+     * another stage or a join operation on the completion stage.
+     * In situations such as these, the executor does not control
+     * the type of thread that is used to run the task.</p>
+     *
+     * @return {@code true} if the executor can create virtual threads,
+     *         otherwise {@code false}.
+     * @since 3.1
+     */
+    boolean virtual() default false;
+
+    /**
      * Enables multiple <code>ManagedScheduledExecutorDefinition</code>
      * annotations on the same type.
      */

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -130,6 +130,26 @@ public @interface ManagedThreadFactoryDefinition {
     int priority() default Thread.NORM_PRIORITY;
 
     /**
+     * <p>Indicates whether this thread factory is requested to
+     * create {@link Thread#isVirtual() virtual} threads.</p>
+     *
+     * <p>When {@code true}, the thread factory can create
+     * virtual threads if it is capable of doing so
+     * and if the request is not overridden by vendor-specific
+     * configuration that restricts the use of virtual threads.</p>
+     *
+     * <p>The default is {@code false}, indicating that the
+     * thread factory must not create virtual threads.
+     * When {@code false}, the thread factory always creates
+     * platform threads.</p>
+     *
+     * @return {@code true} if the thread factory is requested to
+     *         create virtual threads, otherwise {@code false}.
+     * @since 3.1
+     */
+    boolean virtual() default false;
+
+    /**
      * Enables multiple <code>ManagedThreadFactoryDefinition</code>
      * annotations on the same type.
      */

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
fixes #268

This pull adds the virtual=true hint to request the use of virtual threads to ManagedThreadFactoryDefinition, ManagedExecutorDefinition, and ManagedScheduledExecutorDefinition.  The default is false.

Regarding the discussion on the name of the attribute, `virtual` is used because it matches the terminology and hard-coded method names of the java.lang.Thread API, which has methods like [isVirtual](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#isVirtual()) and [ofVirtual](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#ofVirtual()). 