### PR TITLE
Invalid assertion in LastExecutionTests

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/LastExecution/LastExecutionTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/LastExecution/LastExecutionTests.java
@@ -16,11 +16,8 @@
 
 package ee.jakarta.tck.concurrent.api.LastExecution;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ScheduledFuture;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -36,7 +33,6 @@ import ee.jakarta.tck.concurrent.framework.junit.anno.Common;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common.PACKAGE;
 import ee.jakarta.tck.concurrent.framework.junit.anno.TestName;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Web;
-import ee.jakarta.tck.concurrent.framework.junit.extensions.Wait;
 import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ManagedExecutors;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
@@ -72,51 +68,40 @@ public class LastExecutionTests {
         Map<String, String> executionProperties = new HashMap<String, String>();
         executionProperties.put(ManagedTask.IDENTITY_NAME, IDENTITY_NAME_TEST_ID);
 
-        ScheduledFuture<?> sf = scheduledExecutor.schedule(
+        scheduledExecutor.schedule(
                 ManagedExecutors.managedTask(new CounterRunnableTask(), executionProperties, null),
                 new LogicDrivenTrigger(TestConstants.pollInterval.toMillis(), testname));
-        Wait.waitTillFutureIsDone(sf);
-
-        assertEquals(LogicDrivenTrigger.RIGHT_COUNT, // expected
-                StaticCounter.getCount(), // actual
-                "Got wrong identity name. See server log for more details.");
+        
+        StaticCounter.waitTill(LogicDrivenTrigger.RIGHT_COUNT, "Got wrong identity name. See server log for more details.");
     }
 
     @Assertion(id = "JAVADOC:16", strategy = "Result of the last execution.")
     public void lastExecutionGetResultRunnableTest() {
         // test with runnable, LastExecution should return null
-        ScheduledFuture<?> sf = scheduledExecutor.schedule(
+        scheduledExecutor.schedule(
                 ManagedExecutors.managedTask(new CounterRunnableTask(), null, null),
                 new LogicDrivenTrigger(TestConstants.pollInterval.toMillis(), testname));
-        Wait.waitTillFutureIsDone(sf);
-
-        assertEquals(LogicDrivenTrigger.RIGHT_COUNT, // expected
-                StaticCounter.getCount(), // actual
-                "Got wrong last execution result. See server log for more details.");
+        
+        StaticCounter.waitTill(LogicDrivenTrigger.RIGHT_COUNT, "Got wrong last execution result. See server log for more details.");
     }
 
     @Assertion(id = "JAVADOC:16", strategy = "Result of the last execution.")
     public void lastExecutionGetResultCallableTest() {
         // test with callable, LastExecution should return 1
-        ScheduledFuture<?> sf = scheduledExecutor.schedule(
+        scheduledExecutor.schedule(
                 ManagedExecutors.managedTask(new CounterCallableTask(), null, null),
                 new LogicDrivenTrigger(TestConstants.pollInterval.toMillis(), testname));
-        Wait.waitTillFutureIsDone(sf);
-
-        assertEquals(LogicDrivenTrigger.RIGHT_COUNT, // expected
-                StaticCounter.getCount(), // actual
-                "Got wrong last execution result. See server log for more details.");
+        
+        StaticCounter.waitTill(LogicDrivenTrigger.RIGHT_COUNT, "Got wrong last execution result. See server log for more details.");
     }
 
     @Assertion(id = "JAVADOC:17 JAVADOC:18 JAVADOC:19", strategy = "The last time in which the task was completed.")
     public void lastExecutionGetRunningTimeTest() {
-        ScheduledFuture<?> sf = scheduledExecutor.schedule(
+        scheduledExecutor.schedule(
                 ManagedExecutors.managedTask(new CounterRunnableTask(TestConstants.pollInterval), null, null),
                 new LogicDrivenTrigger(TestConstants.pollInterval.toMillis(), testname));
-        Wait.waitTillFutureIsDone(sf);
-        assertEquals(LogicDrivenTrigger.RIGHT_COUNT, // expected
-                StaticCounter.getCount(), // actual
-                "Got wrong last execution result.");
+        
+        StaticCounter.waitTill(LogicDrivenTrigger.RIGHT_COUNT, "Got wrong last execution result. See server log for more details.");
     }
 
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/Trigger/TriggerTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/Trigger/TriggerTests.java
@@ -72,7 +72,7 @@ public class TriggerTests {
             Assertions.assertBetween(StaticCounter.getCount(), TestConstants.pollsPerTimeout - 2,
                     TestConstants.pollsPerTimeout + 2);
         } finally {
-            Wait.waitTillFutureIsDone(result);
+            Wait.waitForTaskComplete(result);
         }
     }
 

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/common/fixed/counter/StaticCounter.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/common/fixed/counter/StaticCounter.java
@@ -44,11 +44,15 @@ public final class StaticCounter {
     }
 
     public static void waitTill(final int expected) {
+        waitTill(expected, "Expected count " + expected + " within timeout.");
+    }
+    
+    public static void waitTill(final int expected, final String message) {
         assertTimeoutPreemptively(TestConstants.waitTimeout, () -> {
             for (; expected != StaticCounter.getCount(); Wait.sleep(TestConstants.pollInterval)) {
                 //empty
             }
-        });
+        }, message);
     }
 
     public static void waitTillSurpassed(final int expected) {

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/junit/extensions/Wait.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/junit/extensions/Wait.java
@@ -73,25 +73,6 @@ public final class Wait {
     }
 
     /**
-     * Waits for future to complete, but will timeout after
-     * {@link TestConstants#waitTimeout}, and will be polled every
-     * {@link TestConstants#pollInterval}
-     *
-     * The difference between this method and waitForTaskComplete is that some
-     * scheduled task will return values for multiple times, in this situation
-     * waitForTaskComplete does not work.
-     *
-     * @param future - the future to wait for
-     */
-    public static void waitTillFutureIsDone(final Future<?> future) {
-        assertTimeoutPreemptively(TestConstants.waitTimeout, () -> {
-            for (; !future.isDone(); sleep(TestConstants.pollInterval)) {
-                //empty
-            }
-        });
-    }
-
-    /**
      * Waits for future to throw an error, but will timeout after
      * {@link TestConstants#waitTimeout}, and will be polled every
      * {@link TestConstants#pollInterval}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/inheritedapi/InheritedAPITests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/inheritedapi/InheritedAPITests.java
@@ -72,16 +72,13 @@ public class InheritedAPITests {
             strategy = "Test basic function for ManagedExecutorService: submit")
     public void testSubmit() throws Exception {
         Future<?> result = executor.submit(new CommonTasks.SimpleCallable());
-        Wait.waitTillFutureIsDone(result);
-        assertEquals(result.get(), TestConstants.simpleReturnValue);
+        assertEquals(Wait.waitForTaskComplete(result), TestConstants.simpleReturnValue);
 
         result = executor.submit(new CommonTasks.SimpleRunnable());
-        Wait.waitTillFutureIsDone(result);
-        result.get();
+        Wait.waitForTaskComplete(result);
 
         result = executor.submit(new CommonTasks.SimpleRunnable(), TestConstants.simpleReturnValue);
-        Wait.waitTillFutureIsDone(result);
-        assertEquals(result.get(), TestConstants.simpleReturnValue);
+        assertEquals(Wait.waitForTaskComplete(result), TestConstants.simpleReturnValue);
     }
 
     @Assertion(id = "SPEC:14.4; SPEC:6.1; SPEC:6.2; SPEC:8",
@@ -119,7 +116,7 @@ public class InheritedAPITests {
             taskList.add(new CommonTasks.SimpleArgCallable(3));
             List<Future<Integer>> resultList = executor.invokeAll(taskList);
             for (Future<?> each : resultList) {
-                Wait.waitTillFutureIsDone(each);
+                Wait.waitForTaskComplete(each);
             }
             assertEquals(resultList.get(0).get(), 1);
             assertEquals(resultList.get(1).get(), 2);
@@ -127,7 +124,7 @@ public class InheritedAPITests {
 
             resultList = executor.invokeAll(taskList, TestConstants.waitTimeout.getSeconds(), TimeUnit.SECONDS);
             for (Future<?> each : resultList) {
-                Wait.waitTillFutureIsDone(each);
+                Wait.waitForTaskComplete(each);
             }
             assertEquals(resultList.get(0).get(), 1);
             assertEquals(resultList.get(1).get(), 2);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/inheritedapi/InheritedAPIServletTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/inheritedapi/InheritedAPIServletTests.java
@@ -67,16 +67,13 @@ public class InheritedAPIServletTests {
     @Assertion(id = "SPEC:44.1", strategy = "Test basic function for ManagedScheduledExecutorService: submit")
     public void testApiSubmit() throws Exception {
         Future<?> result = scheduledExecutor.submit(new CommonTasks.SimpleCallable());
-        Wait.waitTillFutureIsDone(result);
-        assertEquals(result.get(), TestConstants.simpleReturnValue);
+        assertEquals(Wait.waitForTaskComplete(result), TestConstants.simpleReturnValue);
 
         result = scheduledExecutor.submit(new CommonTasks.SimpleRunnable());
-        Wait.waitTillFutureIsDone(result);
-        result.get();
+        Wait.waitForTaskComplete(result);
 
         result = scheduledExecutor.submit(new CommonTasks.SimpleRunnable(), TestConstants.simpleReturnValue);
-        Wait.waitTillFutureIsDone(result);
-        assertEquals(result.get(), TestConstants.simpleReturnValue);
+        assertEquals(Wait.waitForTaskComplete(result), TestConstants.simpleReturnValue);
     }
 
     @Assertion(id = "SPEC:44.2", strategy = "Test basic function for ManagedScheduledExecutorService: execute")
@@ -98,7 +95,7 @@ public class InheritedAPIServletTests {
             taskList.add(new CommonTasks.SimpleArgCallable(3));
             List<Future<Integer>> resultList = scheduledExecutor.invokeAll(taskList);
             for (Future<?> each : resultList) {
-                Wait.waitTillFutureIsDone(each);
+                Wait.waitForTaskComplete(each);
             }
             assertEquals(resultList.get(0).get(), 1);
             assertEquals(resultList.get(1).get(), 2);
@@ -106,7 +103,7 @@ public class InheritedAPIServletTests {
             resultList = scheduledExecutor.invokeAll(taskList, TestConstants.waitTimeout.getSeconds(),
                     TimeUnit.SECONDS);
             for (Future<?> each : resultList) {
-                Wait.waitTillFutureIsDone(each);
+                Wait.waitForTaskComplete(each);
             }
             assertEquals(resultList.get(0).get(), 1);
             assertEquals(resultList.get(1).get(), 2);
@@ -154,13 +151,11 @@ public class InheritedAPIServletTests {
     public void testApiSchedule() throws Exception {
         Future<?> result = scheduledExecutor.schedule(new CommonTasks.SimpleCallable(),
                 TestConstants.pollInterval.getSeconds(), TimeUnit.SECONDS);
-        Wait.waitTillFutureIsDone(result);
-        assertEquals(result.get(), TestConstants.simpleReturnValue);
+        assertEquals(Wait.waitForTaskComplete(result), TestConstants.simpleReturnValue);
 
         result = scheduledExecutor.schedule(new CommonTasks.SimpleRunnable(), TestConstants.pollInterval.getSeconds(),
                 TimeUnit.SECONDS);
-        Wait.waitTillFutureIsDone(result);
-        assertEquals(result.get(), null);
+        assertEquals(Wait.waitForTaskComplete(result), null);
     }
 
     @Assertion(id = "SPEC:44.6", strategy = "Test basic function for ManagedScheduledExecutorService: scheduleAtFixedRate")

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/inheritedapi/TestEjb.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/inheritedapi/TestEjb.java
@@ -54,16 +54,13 @@ public class TestEjb implements TestEjbInterface {
     public void testApiSubmit() {
         try {
             Future<?> result = scheduledExecutor.submit(new CommonTasks.SimpleCallable());
-            Wait.waitTillFutureIsDone(result);
-            assertEquals(result.get(), TestConstants.simpleReturnValue);
+            assertEquals(Wait.waitForTaskComplete(result), TestConstants.simpleReturnValue);
 
             result = scheduledExecutor.submit(new CommonTasks.SimpleRunnable());
-            Wait.waitTillFutureIsDone(result);
-            result.get();
+            Wait.waitForTaskComplete(result);
 
             result = scheduledExecutor.submit(new CommonTasks.SimpleRunnable(), TestConstants.simpleReturnValue);
-            Wait.waitTillFutureIsDone(result);
-            assertEquals(result.get(), TestConstants.simpleReturnValue);
+            assertEquals(Wait.waitForTaskComplete(result), TestConstants.simpleReturnValue);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -87,7 +84,7 @@ public class TestEjb implements TestEjbInterface {
             taskList.add(new CommonTasks.SimpleArgCallable(3));
             List<Future<Integer>> resultList = scheduledExecutor.invokeAll(taskList);
             for (Future<?> each : resultList) {
-                Wait.waitTillFutureIsDone(each);
+                Wait.waitForTaskComplete(each);
             }
             assertEquals(resultList.get(0).get(), 1);
             assertEquals(resultList.get(1).get(), 2);
@@ -96,7 +93,7 @@ public class TestEjb implements TestEjbInterface {
             resultList = scheduledExecutor.invokeAll(taskList, TestConstants.waitTimeout.getSeconds(),
                     TimeUnit.SECONDS);
             for (Future<?> each : resultList) {
-                Wait.waitTillFutureIsDone(each);
+                Wait.waitForTaskComplete(each);
             }
             assertEquals(resultList.get(0).get(), 1);
             assertEquals(resultList.get(1).get(), 2);
@@ -151,13 +148,11 @@ public class TestEjb implements TestEjbInterface {
         try {
             Future<?> result = scheduledExecutor.schedule(new CommonTasks.SimpleCallable(),
                     TestConstants.pollInterval.getSeconds(), TimeUnit.SECONDS);
-            Wait.waitTillFutureIsDone(result);
-            assertEquals(TestConstants.simpleReturnValue, result.get());
+            assertEquals(TestConstants.simpleReturnValue, Wait.waitForTaskComplete(result));
 
             result = scheduledExecutor.schedule(new CommonTasks.SimpleRunnable(),
                     TestConstants.pollInterval.getSeconds(), TimeUnit.SECONDS);
-            Wait.waitTillFutureIsDone(result);
-            assertEquals(result.get(), null);
+            assertEquals(null, Wait.waitForTaskComplete(result));
         } catch (Exception e) {
             fail(e.getMessage());
         }


### PR DESCRIPTION
Fixes #258

Removed `Wait.waitTillFutureIsDone()` because it was misleading.
Fixed the issues where it was being used incorrectly. 
Everywhere else has been switched to `Wait.waitForTaskComplete()`