### PR TITLE
Remove TODOs from TCK that are invalid

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/ContextService/ContextServiceTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/ContextService/ContextServiceTests.java
@@ -44,7 +44,6 @@ import jakarta.enterprise.concurrent.ManagedTaskListener;
 @Common({ PACKAGE.FIXED_COUNTER })
 public class ContextServiceTests {
 
-    // TODO deploy as EJB and JSP artifacts
     @Deployment(name = "ContextServiceTests")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedExecutors/ManagedExecutorsTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedExecutors/ManagedExecutorsTests.java
@@ -52,7 +52,6 @@ import jakarta.enterprise.concurrent.ManagedThreadFactory;
 @Common({ PACKAGE.MANAGED_TASK_LISTENER, PACKAGE.TASKS })
 public class ManagedExecutorsTests {
 
-    // TODO deploy as EJB and JSP artifacts
     @Deployment(name = "ManagedExecutorsTests")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(ManagedExecutorsTests.class.getPackage(),

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedScheduledExecutorService/ManagedScheduledExecutorServiceTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedScheduledExecutorService/ManagedScheduledExecutorServiceTests.java
@@ -43,7 +43,6 @@ import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 @Common({ PACKAGE.TASKS })
 public class ManagedScheduledExecutorServiceTests {
 
-    // TODO deploy as EJB and JSP artifacts
     @Deployment(name = "ManagedScheduledExecutorServiceTests")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedTask/ManagedTaskTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedTask/ManagedTaskTests.java
@@ -39,7 +39,6 @@ import jakarta.enterprise.concurrent.ManagedTask;
 @Common({ PACKAGE.MANAGED_TASK_LISTENER, PACKAGE.TASKS })
 public class ManagedTaskTests {
 
-    // TODO deploy as EJB and JSP artifacts
     @Deployment(name = "ManagedTaskTests")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class).addPackages(true, ManagedTaskTests.class.getPackage());

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedTaskListener/ManagedTaskListenerTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedTaskListener/ManagedTaskListenerTests.java
@@ -49,7 +49,6 @@ public class ManagedTaskListenerTests {
 
     private static final TestLogger log = TestLogger.get(ManagedTaskListenerTests.class);
 
-    // TODO deploy as EJB and JSP artifacts
     @Deployment(name = "ManagedTaskListenerTests")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class).addPackages(true, ManagedTaskListenerTests.class.getPackage());

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/SkippedException/SkippedExceptionTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/SkippedException/SkippedExceptionTests.java
@@ -32,7 +32,6 @@ import jakarta.enterprise.concurrent.SkippedException;
 @Web // TODO couldn't this be a unit test?
 public class SkippedExceptionTests {
 
-    // TODO deploy as EJB and JSP artifacts
     @Deployment(name = "SkippedExceptionTests")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class).addPackages(true, SkippedExceptionTests.class.getPackage());

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/Trigger/TriggerTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/Trigger/TriggerTests.java
@@ -46,7 +46,6 @@ import jakarta.enterprise.concurrent.SkippedException;
 @Common({ PACKAGE.FIXED_COUNTER, PACKAGE.TASKS })
 public class TriggerTests {
 
-    // TODO deploy as EJB and JSP artifacts
     @Deployment(name = "TriggerTests")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class).addPackages(true, TriggerTests.class.getPackage());

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionFullTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionFullTests.java
@@ -65,8 +65,6 @@ public class ManagedExecutorDefinitionFullTests extends TestClient {
                         ManagedExecutorDefinitionServlet.class, ManagedExecutorDefinitionOnEJBServlet.class,
                         ContextServiceDefinitionServlet.class)
                 .addClasses(ContextServiceDefinitionInterface.class, ContextServiceDefinitionBean.class);
-        // TODO document how users can dynamically inject vendor specific deployment
-        // descriptors into this archive
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ManagedExecutorDefinitionTests.ear")
                 .addAsModules(war, jar);


### PR DESCRIPTION
Fixes #178 

No one in this repository nor on the mailing list has raised any opposition to running our API tests only in a servlet and not repeating them using Enterprise Beans or Pages.