### PR TITLE
missed qualifiers in resource definition example

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,6 +38,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@literal @}ContextServiceDefinition(
  *     name = "java:app/concurrent/MyContext",
+ *     qualifiers = MyQualifier.class,
  *     propagated = APPLICATION,
  *     unchanged = TRANSACTION,
  *     cleared = ALL_REMAINING)

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -39,6 +39,7 @@ import java.lang.annotation.Target;
  * <pre>
  * {@literal @}ManagedScheduledExecutorDefinition(
  *     name = "java:comp/concurrent/MyScheduledExecutor",
+ *     qualifiers = MyQualifier.class,
  *     context = "java:comp/concurrent/MyScheduledExecutorContext",
  *     hungTaskThreshold = 30000,
  *     maxAsync = 3)

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -39,6 +39,7 @@ import java.lang.annotation.Target;
  * <pre>
  * {@literal @}ManagedThreadFactoryDefinition(
  *     name = "java:global/concurrent/MyThreadFactory",
+ *     qualifiers = MyQualifier.class,
  *     context = "java:global/concurrent/MyThreadFactoryContext",
  *     priority = 4)
  * {@literal @}ContextServiceDefinition(


### PR DESCRIPTION
Fixes the [issue](https://github.com/jakartaee/concurrency/pull/348/files/e743973a54e2a5f1354e9592824f398026b67c6d#r1341093857) found by @OndroMih where `qualifiers = MyQualifier.class` was accidentally omitted from the JavaDoc example.