### PR TITLE
Updating jruby dependency

### DIFF
--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -51,10 +51,10 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.10</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
-        <!-- jruby 9.4.3.0 is not working, keeping this on the 9.3.x stream since 9.4 seems to implement a newer ruby version
+        <!-- Keeping this on the 9.3.x stream since 9.4 seems to implement a newer ruby version
         which is causing issues with asciidoctor, even though asciidoctorj considers it compatible.
         Looks like this may work with the asciidoctorj 3.0.0 stream when it releases-->
-        <jruby.version>9.3.10.0</jruby.version> 
+        <jruby.version>9.3.11.0</jruby.version> 
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>


### PR DESCRIPTION
Bumping the jruby dependency to 9.3.11.0. The 9.4 stream is still not compatible with the latest asciidoctorj