### PR TITLE
Concurrency project housekeeping

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,32 +3,32 @@ description: Jakarta Concurrency Bug Report
 title: "[Bug]: "
 labels: ["bug"] #Verified - label exists
 body:
-- type: markdown
-  attributes: 
-    value: >
-      Report a mistake or inconsistency in the specification code, TCK tests, or documentation text.
-      If error is related to a TCK test after release, then use the TCK Challenge template instead.
-- type: dropdown
-  id: version
-  validations:
-    required: true
-  attributes: 
-    label: Specification Version
-    description: What version of the Concurrency Spec are you running using? 
-    options: #TODO need to update this list per release
-      - 3.1.0-SNAPSHOT (Locally built)
-      - 3.0.2          (Generally available)
-      - 3.0.1          (Generally available)
-      - 3.0.0          (Generally available)
-- type: textarea
-  validations:
-    required: true
-  attributes:
-    label: Bug report
-    value: |
-      > Description of the bug found.
-- type: textarea
-  attributes:
-    label: Additional information
-    value: |
-      > Proposed solutions, code examples, ect. 
+  - type: markdown
+    attributes: 
+      value: |
+        > Report a mistake or inconsistency in the specification code, TCK tests, or documentation text.
+        > If error is related to a TCK test after release, then use the TCK Challenge template instead.
+  - type: dropdown
+    id: version
+    validations:
+      required: true
+    attributes: 
+      label: Specification Version
+      description: What version of the Concurrency Spec are you running using? 
+      options: #TODO need to update this list per release
+        - 3.1.0-SNAPSHOT (Locally built)
+        - 3.0.2          (Generally available)
+        - 3.0.1          (Generally available)
+        - 3.0.0          (Generally available)
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Bug report
+      placeholder: |
+        > Description of the bug found.
+  - type: textarea
+    attributes:
+      label: Additional information
+      placeholder: |
+        > Proposed solutions, code examples, ect. 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,11 +15,11 @@ body:
     attributes: 
       label: Specification Version
       description: What version of the Concurrency Spec are you running using? 
-      options: #TODO need to update this list per release
-        - 3.1.0-SNAPSHOT (Locally built)
-        - 3.0.2          (Generally available)
-        - 3.0.1          (Generally available)
-        - 3.0.0          (Generally available)
+      options:
+        - 3.0.2
+        - 3.0.1
+        - 3.0.0
+        - SNAPSHOT (Locally built)
   - type: textarea
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/certification.yml
+++ b/.github/ISSUE_TEMPLATE/certification.yml
@@ -3,94 +3,92 @@ description: Jakarta Concurrency Platform Certification
 title: "[Certification]: "
 labels: ["certification"] #Verified - label exists
 body:
-- type: markdown
-  attributes: 
-    value: >
-      Before submitting a Platform Certification to the Jakarta Concurrency community 
-      please read and be familiar with the 
-      [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) 
-      which may be updated occasionally.
-- type: input
-  id: organization
-  validations:
-    required: true
-  attributes: 
-    label: Organization
-    description: Organization name and URL (if applicable)
-- type: input
-  id: implementation
-  validations:
-    required: true
-  attributes: 
-    label: Implementation
-    description: Product name, version, and download URL (if applicable)
-- type: input
-  id: specification
-  validations:
-    required: true
-  attributes: 
-    label: Specification
-    description: Specification name, version, and download URL (if applicable)
-- type: input
-  id: tck
-  validations:
-    required: true
-  attributes: 
-    label: Technology Compatibility Kit (TCK)
-    description: TCK name, version, and download URL (if applicable)
-- type: input
-  id: tckSHA
-  validations:
-    required: true
-  attributes: 
-    label: Technology Compatibility Kit (TCK) Validation
-    description: TCK SHA-256 fingerprint
-- type: textarea
-  id: tckResults
-  validations:
-    required: true
-  attributes: 
-    label: Technology Compatibility Kit (TCK) Results
-    description: |
-      Public URL of TCK Results Summary
-      TIP: You can attach TCK Results to this issue by clicking this area to highlight it and then dragging files in.
-- type: textarea
-  id: additionalRequirements
-  validations:
-    required: true
-  attributes:
-    label: Additional Specification Requirements
-    description: >
-      Specification projects may require additional items for a Certification Request 
-      as defined in their corresponding TCK Documentation under the section labeled "Additional Certification Requirements".
-- type: textarea
-  id: javaRuntime
-  validations:
-    required: true
-  attributes:
-    label: Java Runtime(s)
-    description: |
-      Java runtime(s) used to run the implementation.
-      Output from `java -version`
-- type: textarea
-  id: environment
-  validations:
-    required: true
-  attributes:
-    label: Environments
-    description: Summary of the information for the certification environment, operating system, cloud, etc.
-- type: checkboxes
-  id: ackEFTL
-  attributes:
-    label: Eclipse Foundation Technology Compatibility Kit License (EFTL)
-    description: Do you accept the terms of the (EFTL)?
-    options:
-    - label: By checking this box I acknowledge that the organization I represent accepts the terms of the [EFTL](https://www.eclipse.org/legal/tck.php)
+  - type: markdown
+    attributes: 
+      value: |
+        > Before submitting a Platform Certification to the Jakarta Concurrency community please read and be familiar with the 
+        > [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.
+  - type: input
+    id: organization
+    validations:
       required: true
-- type: checkboxes
-  id: ackRules
-  attributes:
-    label: TCK Requirements and Compatibility
-    options:
-    - label: By checking this box I attest that all TCK requirements have been met, including any compatibility rules.
+    attributes: 
+      label: Organization
+      description: Organization name and URL (if applicable)
+  - type: input
+    id: implementation
+    validations:
       required: true
+    attributes: 
+      label: Implementation
+      description: Product name, version, and download URL (if applicable)
+  - type: input
+    id: specification
+    validations:
+      required: true
+    attributes: 
+      label: Specification
+      description: Specification name, version, and download URL (if applicable)
+  - type: input
+    id: tck
+    validations:
+      required: true
+    attributes: 
+      label: Technology Compatibility Kit (TCK)
+      description: TCK name, version, and download URL (if applicable)
+  - type: input
+    id: tckSHA
+    validations:
+      required: true
+    attributes: 
+      label: Technology Compatibility Kit (TCK) Validation
+      description: TCK SHA-256 fingerprint
+  - type: textarea
+    id: tckResults
+    validations:
+      required: true
+    attributes: 
+      label: Technology Compatibility Kit (TCK) Results
+      description: |
+        Public URL of TCK Results Summary
+        TIP: You can attach TCK Results to this issue by clicking this area to highlight it and then dragging files in.
+  - type: textarea
+    id: additionalRequirements
+    validations:
+      required: true
+    attributes:
+      label: Additional Specification Requirements
+      description: |
+        Specification projects may require additional items for a Certification Request 
+        as defined in their corresponding TCK Documentation under the section labeled "Additional Certification Requirements".
+  - type: textarea
+    id: javaRuntime
+    validations:
+      required: true
+    attributes:
+      label: Java Runtime(s)
+      description: |
+        Java runtime(s) used to run the implementation.
+        Output from `java -version`
+  - type: textarea
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: Environments
+      description: Summary of the information for the certification environment, operating system, cloud, etc.
+  - type: checkboxes
+    id: ackEFTL
+    attributes:
+      label: Eclipse Foundation Technology Compatibility Kit License (EFTL)
+      description: Do you accept the terms of the (EFTL)?
+      options:
+      - label: By checking this box I acknowledge that the organization I represent accepts the terms of the [EFTL](https://www.eclipse.org/legal/tck.php)
+        required: true
+  - type: checkboxes
+    id: ackRules
+    attributes:
+      label: TCK Requirements and Compatibility
+      options:
+      - label: By checking this box I attest that all TCK requirements have been met, including any compatibility rules.
+        required: true

--- a/.github/ISSUE_TEMPLATE/clarification.yml
+++ b/.github/ISSUE_TEMPLATE/clarification.yml
@@ -3,28 +3,28 @@ description: Jakarta Concurrency Clarification
 title: "[clarification]: "
 labels: ["question"] #Verified - label exists
 body:
-- type: markdown
-  attributes: 
-    value: >
-      Request that some aspect of the specification be clarified.
-- type: input
-  id: specification
-  validations:
-    required: true
-  attributes: 
-    label: Specification
-    description: What specification is the clarification related to? Provide a link to the API class or SPEC document section. 
-    placeholder: |
-      ex. [Aborted Exception](https://github.com/jakartaee/concurrency/blob/master/api/src/main/java/jakarta/enterprise/concurrent/AbortedException.java#L22)
-- type: textarea
-  validations:
-    required: true
-  attributes:
-    label: I need clarification on ...
-    value: |
-      > Description of the clarification needed.
-- type: textarea
-  attributes:
-    label: Additional information
-    value: |
-      > Proposed solutions, code examples, ect. 
+  - type: markdown
+    attributes: 
+      value: |
+        > Request that some aspect of the specification be clarified.
+  - type: input
+    id: specification
+    validations:
+      required: true
+    attributes: 
+      label: Specification
+      description: What specification is the clarification related to? Provide a link to the API class or SPEC document section. 
+      placeholder: |
+        ex. [Aborted Exception](https://github.com/jakartaee/concurrency/blob/master/api/src/main/java/jakarta/enterprise/concurrent/AbortedException.java#L22)
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: I need clarification on ...
+      placeholder: |
+        > Description of the clarification needed.
+  - type: textarea
+    attributes:
+      label: Additional information
+      placeholder: |
+        > Proposed solutions, code examples, ect. 

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -34,7 +34,6 @@ body:
           #### Prepare
             - [X] Open this issue.
             - [ ] Complete outstanding work
-            - [ ] (Update TCK Signatures to capture API changes)[https://github.com/jakartaee/concurrency/blob/main/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/README.md#generating-the-signature-file]
           #### Stage release
             - [ ] [Build and stage artifacts to staging repository](https://ci.eclipse.org/cu/view/Release/job/concurrency_api_1-build-and-stage/)
             - [ ] [Build and stage the TCK distribution artifact to download.eclipse.org](https://ci.eclipse.org/cu/view/Release/job/concurrency_tck_1-build-and-stage/)

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -48,7 +48,8 @@ body:
             - [ ] Update this issue with a comment that links to the published artifacts and the generated GitHub branch and tag
             - [ ] [Modify the `pre-release` on GitHub to be `latest`](https://github.com/jakartaee/concurrency/releases)
           #### Follow up
-            - [ ] [Email a Jakarta steering committee member to promote the TCK Distribution publically](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/)
+            - [ ] [Email the Concurrency Mailing list to have a Jakarta Steering Committee member promote the TCK Distribution publically](https://accounts.eclipse.org/mailing-list/cu-dev)
+              - via [Jenkins build](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/)
             - [ ] Update versions in non-build files, such as:
               Documentation:
               - [tck/README.adoc](https://github.com/jakartaee/concurrency/tree/main/tck#getting-the-tck)

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -1,0 +1,58 @@
+name: Release
+description: Propose a new minor/major release
+title: "[Release]: "
+labels: ["release"] #Verified - label exists
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        This issue is to help the committers to the Jakarta Concurrency project to propose
+        and complete the release process.
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: |
+        Why is a release needed?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Outstanding work
+      description: |
+        Issues / pulls to finish before this release can become generally available.
+      value: |
+        - [ ] 
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Check List
+      description: |
+        This is a checklist of what needs to be completed during the release process.
+        This checklist typically does not need to be edited prior to submitting this form.
+      value: |
+          #### Prepare
+            - [X] Open this issue.
+            - [ ] Complete outstanding work
+            - [ ] (Update TCK Signatures to capture API changes)[https://github.com/jakartaee/concurrency/blob/main/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/README.md#generating-the-signature-file]
+          #### Stage release
+            - [ ] [Build and stage artifacts to staging repository](https://ci.eclipse.org/cu/view/Release/job/concurrency_api_1-build-and-stage/)
+            - [ ] [Build and stage the TCK distribution artifact to download.eclipse.org](https://ci.eclipse.org/cu/view/Release/job/concurrency_tck_1-build-and-stage/)
+            - [ ] Update this issue with a comment that links to the staged artifacts and the generated GitHub branch and tag
+            - [ ] [Create a `pre-release` on GitHub](https://github.com/jakartaee/concurrency/releases/new)
+          #### Verify and modify
+            - [ ] Ask for feedback from the community to verify the staged artifact has all the expected changes.
+            - [ ] If anything needs to be added before publishing do that now and repeat the `Stage Release` section
+          #### Publish release
+            - [ ] [Publish staged artifacts to the public repository](https://ci.eclipse.org/cu/view/Release/job/concurrency_api_3-staging-to-release/)
+            - [ ] [Publish staged TCK distribution artifact to download.eclipse.org](https://ci.eclipse.org/cu/view/Release/job/concurrency_tck_2-staging-to-promoted/)
+            - [ ] Update this issue with a comment that links to the published artifacts and the generated GitHub branch and tag
+            - [ ] [Modify the `pre-release` on GitHub to be `latest`](https://github.com/jakartaee/concurrency/releases)
+          #### Follow up
+            - [ ] [Email a Jakarta steering committee member to promote the TCK Distribution publically](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/)
+            - [ ] Update versions in non-build files, such as:
+              Documentation:
+              - [tck/README.adoc](https://github.com/jakartaee/concurrency/tree/main/tck#getting-the-tck)
+              - [concurrency-tck-reference-guide.adoc](https://github.com/jakartaee/concurrency/blob/main/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/tck-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/tck-challenge.yml
@@ -3,86 +3,84 @@ description: Jakarta Concurrency TCK Challenge
 title: "[TCK Challenge]: "
 labels: ["challenge"] #Verified - label exists
 body:
-- type: markdown
-  attributes: 
-    value: >
-      Before submitting a TCK Challenge to the Jakarta Concurrency community 
-      please read and be familiar with the 
-      [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) 
-      which may be updated occasionally.
-- type: input
-  id: specification
-  validations:
-    required: true
-  attributes: 
-    label: Specification
-    description: What specification is the challenge related to? Provide a link to the API class or SPEC document section. 
-    placeholder: |
-      ex. [Aborted Exception](https://github.com/jakartaee/concurrency/blob/master/api/src/main/java/jakarta/enterprise/concurrent/AbortedException.java#L22)
-- type: input
-  id: assertion
-  validations:
-    required: true
-  attributes: 
-    label: Assertion
-    description: What assertion is the challenge related to? Provide a link to the assertion description
-    placeholder: |
-      ex. [AbortedExceptionNoArgTest](https://github.com/jakartaee/concurrency/blob/master/tck/src/main/java/ee/jakarta/tck/concurrent/api/AbortedException/AbortedExceptionTests.java#L47)
-- type: dropdown
-  id: version
-  validations:
-    required: true
-  attributes: 
-    label: TCK Version
-    description: What version of the TCK are you running against? 
-    options: #TODO need to update this list per release
-      - 1.0.0-SNAPSHOT (Locally built)
-      - 1.0.0-RC1      (Release candidate)
-      - 1.0.0          (Generally available)
-- type: input
-  id: implementation
-  validations:
-    required: true
-  attributes: 
-    label: Implementation being tested
-    description: What implementation is being tested? Include name of company/organization
-    placeholder: |
-      ex. Open Liberty / IBM
-- type: dropdown
-  id: challengeType
-  validations:
-    required: true
-  attributes: 
-    label: Challenge Scenario
-    description: Which of the following scenarios best match this challenge? 
-    options: 
-      - Claims that a test assertion conflicts with the specification.
-      - Claims that a test asserts requirements over and above that of the specification.
-      - Claims that an assertion of the specification is not sufficiently implementable.
-      - Claims that a test is not portable or depends on a particular implementation.
-      - Something else
-- type: textarea
-  id: fullDescription
-  validations:
-    required: true
-  attributes:
-    label: Full Description
-    description: |
-      Describe the challenge in full detail including logs.
-      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-    value: |
-      > Description of issue using markdown syntax
-- type: textarea
-  id: additionalContext
-  attributes:
-    label: Additional Context
-    description: Additional context about the problem, possible solutions, alternative interpretations, etc.
-- type: checkboxes
-  attributes:
-    label: Is there an existing challenge for this?
-    description: |
-      Please search to see if a challenge already exists, or has been approved, that matches your challenge.
-      https://github.com/jakartaee/concurrency/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Achallenge
-    options:
-    - label: I have searched the existing issues
+  - type: markdown
+    attributes: 
+      value: |
+        > Before submitting a TCK Challenge to the Jakarta Concurrency community please read and be familiar with the 
+        > [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.
+  - type: input
+    id: specification
+    validations:
       required: true
+    attributes: 
+      label: Specification
+      description: What specification is the challenge related to? Provide a link to the API class or SPEC document section. 
+      placeholder: |
+        ex. [Aborted Exception](https://github.com/jakartaee/concurrency/blob/master/api/src/main/java/jakarta/enterprise/concurrent/AbortedException.java#L22)
+  - type: input
+    id: assertion
+    validations:
+      required: true
+    attributes: 
+      label: Assertion
+      description: What assertion is the challenge related to? Provide a link to the assertion description
+      placeholder: |
+        ex. [AbortedExceptionNoArgTest](https://github.com/jakartaee/concurrency/blob/master/tck/src/main/java/ee/jakarta/tck/concurrent/api/AbortedException/AbortedExceptionTests.java#L47)
+  - type: dropdown
+    id: version
+    validations:
+      required: true
+    attributes: 
+      label: TCK Version
+      description: What version of the TCK are you running against? 
+      options: #TODO need to update this list per release
+        - 1.0.0-SNAPSHOT (Locally built)
+        - 1.0.0-RC1      (Release candidate)
+        - 1.0.0          (Generally available)
+  - type: input
+    id: implementation
+    validations:
+      required: true
+    attributes: 
+      label: Implementation being tested
+      description: What implementation is being tested? Include name of company/organization
+      placeholder: |
+        ex. Open Liberty / IBM
+  - type: dropdown
+    id: challengeType
+    validations:
+      required: true
+    attributes: 
+      label: Challenge Scenario
+      description: Which of the following scenarios best match this challenge? 
+      options: 
+        - Claims that a test assertion conflicts with the specification.
+        - Claims that a test asserts requirements over and above that of the specification.
+        - Claims that an assertion of the specification is not sufficiently implementable.
+        - Claims that a test is not portable or depends on a particular implementation.
+        - Something else
+  - type: textarea
+    id: fullDescription
+    validations:
+      required: true
+    attributes:
+      label: Full Description
+      description: |
+        Describe the challenge in full detail including logs.
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      placeholder: |
+        > Description of issue using markdown syntax
+  - type: textarea
+    id: additionalContext
+    attributes:
+      label: Additional Context
+      description: Additional context about the problem, possible solutions, alternative interpretations, etc.
+  - type: checkboxes
+    attributes:
+      label: Is there an existing challenge for this?
+      description: |
+        Please search to see if a challenge already exists, or has been approved, that matches your challenge.
+        https://github.com/jakartaee/concurrency/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Achallenge
+      options:
+      - label: I have searched the existing issues
+        required: true

--- a/.github/ISSUE_TEMPLATE/tck-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/tck-challenge.yml
@@ -33,10 +33,11 @@ body:
     attributes: 
       label: TCK Version
       description: What version of the TCK are you running against? 
-      options: #TODO need to update this list per release
-        - 1.0.0-SNAPSHOT (Locally built)
-        - 1.0.0-RC1      (Release candidate)
-        - 1.0.0          (Generally available)
+      options:
+        - 3.0.2
+        - 3.0.1
+        - 3.0.0
+        - SNAPSHOT (Locally built)
   - type: input
     id: implementation
     validations:

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -3,34 +3,34 @@ description: Jakarta Concurrency Use Case
 title: "[Use Case]: "
 labels: ["enhancement"] #Verified - label exists
 body:
-- type: markdown
-  attributes: 
-    value: >
-      Describe a new use case for the specification.
-- type: checkboxes
-  attributes:
-    label: As a ...
-    options:
-    - label: Application user/user of the configuration itself
-    - label: API user (application developer)
-    - label: SPI user (container or runtime developer)
-    - label: Specification implementer
-- type: textarea
-  validations:
-    required: true
-  attributes:
-    label: I need to be able to ...
-    value: |
-      > Description of the new or different use case
-- type: textarea
-  validations:
-    required: true
-  attributes:
-    label: Which enables me to ...
-    value: |
-      > Description of the added value of this use case
-- type: textarea
-  attributes:
-    label: Additional information
-    value: |
-      > Proposed solutions, code examples, ect. 
+  - type: markdown
+    attributes: 
+      value: |
+        > Describe a new use case for the specification.
+  - type: checkboxes
+    attributes:
+      label: As a ...
+      options:
+      - label: Application user/user of the configuration itself
+      - label: API user (application developer)
+      - label: SPI user (container or runtime developer)
+      - label: Specification implementer
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: I need to be able to ...
+      placeholder: |
+        > Description of the new or different use case
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Which enables me to ...
+      placeholder: |
+        > Description of the added value of this use case
+  - type: textarea
+    attributes:
+      label: Additional information
+      placeholder: |
+        > Proposed solutions, code examples, ect. 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: /
     schedule:
       interval: daily
+    labels:
+      - "dependencies"
+      - "bot"
 
   - package-ecosystem: maven
     directory: /
     schedule:
       interval: daily
+    labels:
+      - "dependencies"
+      - "bot"

--- a/.github/workflows/ci-pull.yml
+++ b/.github/workflows/ci-pull.yml
@@ -1,11 +1,9 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Java CI with Maven on Pull
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -14,18 +12,20 @@ permissions:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        java-version: [ '17', '21' ]
+
+    # TODO Enable strategy for next Jakarta Release Cycle
+    # strategy:
+    #   matrix:
+    #     java-version: [ '21', '25-ea' ]
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 21 #${{ matrix.java-version }}
       uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
       with:
-        java-version: ${{ matrix.java-version }}
+        java-version: 21 #${{ matrix.java-version }}
         distribution: 'temurin'
         cache: maven
     - name: Build API, SPEC, and TCK

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,55 @@
+# This workflow does continuous deployment of generated files based off of changes pushed to `main`
+
+name: Java CD with Maven on Push
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # TODO Enable strategy for next Jakarta Release Cycle
+    # strategy:
+    #   matrix:
+    #     java-version: [ '21', '25-ea' ]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Set up JDK 21 #${{ matrix.java-version }}
+      uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+      with:
+        java-version: 21 #${{ matrix.java-version }}
+        distribution: 'temurin'
+        cache: maven
+    - name: Build project
+      run: mvn -B install --file pom.xml
+    - name: Checkout branch
+      run: git checkout -b update-generated-files-${{ github.sha }}
+    - name: Generate signatures
+      run: mvn package -Psignature-generation --file tck/pom.xml
+    ## Add any other automated update steps here
+    - name: Needs updates
+      id: update
+      run: |
+        echo "update_count=$(git status -s -uno | wc -l)" >> $GITHUB_OUTPUT
+        echo "update_files=$(git status -s -uno)"         >> $GITHUB_OUTPUT
+    - name: Create pull request
+      if: steps.update.outputs.update_count > 0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+
+        git add -u
+        git commit -m "Update generated files"
+        git push origin update-generated-files-${{ github.sha }}
+
+        gh pr create \
+            -B main \
+            --title 'Update generated files' \
+            --body '${{ steps.update.outputs.update_files }}' \
+            --label 'bot'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ '17', '21-ea' ]
+        java-version: [ '17', '21' ]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+# This workflow will run when a release is created, and automatically update GitHub issue templates
+
+name: GitHub Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Create branch
+      run: |
+        git checkout -b update-templates
+    - name: Insert release - ${{ github.event.release.tag_name }}
+      uses: mikefarah/yq@a198f72367ce9da70b564a2cc25399de8e27bf37 #v4.35.2
+      with:
+        cmd: |
+            yq -i '( .body.[] | select(.id == "version") ) ref $x | $x .attributes.options = ["${{ github.event.release.tag_name }}"] + $x .attributes.options' .github/ISSUE_TEMPLATE/bug-report.yml &&
+            yq -i '( .body.[] | select(.id == "version") ) ref $x | $x .attributes.options = ["${{ github.event.release.tag_name }}"] + $x .attributes.options' .github/ISSUE_TEMPLATE/tck-challenge.yml
+    - name: Create Pull Request
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git add .github/ISSUE_TEMPLATE/bug-report.yml
+        git add .github/ISSUE_TEMPLATE/tck-challenge.yml
+        git commit -m "Update templates to include release ${{ github.event.release.tag_name }}"
+        git push origin update-templates
+        gh pr create -B main --title 'Update templates to include release ${{ github.event.release.tag_name }}' --body 'Created by Github action' --label 'version'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,25 +11,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: checkout
+    - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Create branch
-      run: |
-        git checkout -b update-templates
+      run: git checkout -b update-templates-${{ github.sha }}
     - name: Insert release - ${{ github.event.release.tag_name }}
       uses: mikefarah/yq@a198f72367ce9da70b564a2cc25399de8e27bf37 #v4.35.2
       with:
         cmd: |
             yq -i '( .body.[] | select(.id == "version") ) ref $x | $x .attributes.options = ["${{ github.event.release.tag_name }}"] + $x .attributes.options' .github/ISSUE_TEMPLATE/bug-report.yml &&
             yq -i '( .body.[] | select(.id == "version") ) ref $x | $x .attributes.options = ["${{ github.event.release.tag_name }}"] + $x .attributes.options' .github/ISSUE_TEMPLATE/tck-challenge.yml
+    - name: Needs updates
+      id: update
+      run: |
+        echo "update_count=$(git status -s -uno | wc -l)" >> $GITHUB_OUTPUT
+        echo "update_files=$(git status -s -uno)"         >> $GITHUB_OUTPUT
     - name: Create Pull Request
+      if: steps.update.outputs.update_count > 0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
+
         git add .github/ISSUE_TEMPLATE/bug-report.yml
         git add .github/ISSUE_TEMPLATE/tck-challenge.yml
+
         git commit -m "Update templates to include release ${{ github.event.release.tag_name }}"
-        git push origin update-templates
-        gh pr create -B main --title 'Update templates to include release ${{ github.event.release.tag_name }}' --body 'Created by Github action' --label 'version'
+        git push origin update-templates-${{ github.sha }}
+
+        gh pr create \
+          -B main \
+          --title 'Update templates to include release ${{ github.event.release.tag_name }}' \
+          --body '${{ steps.update.outputs.update_files }}' \
+          --label 'version' \
+          --label 'bot'

--- a/tck-dist/src/main/artifacts/artifact-install.sh
+++ b/tck-dist/src/main/artifacts/artifact-install.sh
@@ -5,7 +5,8 @@
 if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
   VERSION="$1"
 else
-  VERSION="3.0.1"
+  echo "A valid version is required to execute this script"
+  exit 1
 fi
 
 # Parent pom

--- a/tck/README.md
+++ b/tck/README.md
@@ -45,7 +45,7 @@ Including the TCK as a dependency in your project can be obtained from Maven Cen
 <dependency>
     <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.3</version>
 </dependency>
 ```
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -240,6 +240,8 @@
                             </execution>
                         </executions>
                     </plugin>
+                    
+                    <!-- Extract JDK modules into output directory for use by signature plugin -->
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
@@ -262,6 +264,8 @@
                             </arguments>
                         </configuration>
                     </plugin>
+                    
+                    <!-- Run signature plugin to generate signature file -->
                     <plugin>
                         <groupId>org.netbeans.tools</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
@@ -269,6 +273,7 @@
                         <executions>
                             <execution>
                                 <id>createSigFile</id>
+                                <phase>generate-resources</phase>
                                 <goals>
                                     <goal>generate</goal>
                                 </goals>
@@ -282,8 +287,37 @@
                                 jakarta.enterprise.concurrent.spi,
                             </packages>
                             <attach>false</attach>
-                            <sigfile>${project.build.directory}/jakarta.enterprise.concurrent.sig_${project.version}</sigfile>
+                            <sigfile>${project.build.directory}/jakarta.enterprise.concurrent.sig_${java.version}</sigfile>
                         </configuration>
+                    </plugin>
+                    
+                    <!-- Copy signature file to tck resources with major java version -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>copySigFile</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${project.basedir}/src/main/resources/ee/jakarta/tck/concurrent/common/signature/" />
+                                        <copy todir="${project.basedir}/src/main/resources/ee/jakarta/tck/concurrent/common/signature/">
+                                            <fileset
+                                                dir="${project.build.directory}"
+                                                includes="jakarta.enterprise.concurrent.sig_${java.version}" />
+                                            <mapper
+                                                from="^(jakarta.enterprise.concurrent.sig_[0-9]+)"
+                                                to="\1" type="regexp" />
+                                        </copy>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/ConcurrencySignatureTestRunner.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/ConcurrencySignatureTestRunner.java
@@ -16,7 +16,6 @@
 package ee.jakarta.tck.concurrent.common.signature;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
@@ -311,11 +310,6 @@ public class ConcurrencySignatureTestRunner extends SigTestEE {
         // signature testing
         assertNotNull(System.getProperty("jimage.dir"),
                 "The system property jimage.dir must be set in order to run the Signature test.");
-
-        // Ensure user is running on JDK 11 or higher, different JDKs produce different
-        // signatures
-        int javaSpecVersion = Integer.parseInt(System.getProperty("java.specification.version"));
-        assertTrue(javaSpecVersion >= 11, "The signature tests must be run on a JVM using Java 11 or higher.");
 
         // Ensure user has the correct security/JDK settings to allow the plugin access
         // to internal JDK classes.

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/README.md
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/README.md
@@ -49,24 +49,23 @@ The plugin that generates the signature file has been copied below for reference
 
 ### Generating the Signature File
 
-To generate the signature file go to the TCK project:
+To generate the signature file first build the API:
 
 ```sh
-cd tck
+cd api
+mvn package
 ```
 
-Use Maven to build the TCK and run the custom profile to generate the signature file:
+Then build the TCK with the `signature-generation` profile to re-generate the signature file:
 
 ```sh
-mvn install -Psignature-generation
+cd ../tck
+mvn package -Psignature-generation
 ```
 
 The signature file will be generated in the `/target/` directory.
 
-The signature file name expected is `jakarta.enterprise.concurrent.sig_${version}`, where version is the api version form which the signature is generated.
-
-Copy the signature file to the TCK so that it can be used by the test project, and checked into version control.
-`src/main/resources/ee/jakarta/tck/concurrent/spec/signature`
+The signature file will be automatically copied to the `/src/main/resource/ee/jakarta/tck/concurrent/common/signature/` directory.
 
 ## For TCK users
 

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/README.md
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/common/signature/README.md
@@ -49,6 +49,9 @@ The plugin that generates the signature file has been copied below for reference
 
 ### Generating the Signature File
 
+> NOTE: A GitHub actions workflow automatically updates signature files after API updates so this only needs to happen 
+> when creating a new signature file for a newly support JDK level.
+
 To generate the signature file first build the API:
 
 ```sh


### PR DESCRIPTION
This PR does the following housekeeping for the Concurrency project:

- Updates the CI builds to use Java 21 GA (instead of EA)
- Updates issue templates to be valid YML
- Adds a release template that will make it easier to keep track of tasks needed to create a release
- Adds a workflow that will automatically update our issue templates with updated versions
- Updates the signature file generation task to automatically copy and rename the signature file into the TCK resources.
- Creates a workflow that will automatically open a PR to update the signature files when updates to API are merged.
- Removes the requirement for updating the signature test based on Jakarta + JDK version support (instead we can just assume if a signature file for a certain JDK version doesn't exist then it isn't supported by the Jakarta release)