### PR TITLE
Adding Flow Subscriber APIs to ContextService

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
@@ -221,20 +221,40 @@ public interface ContextService {
    * <p>Wraps a {@link java.util.concurrent.Flow.Subscriber} with context captured from the thread that invokes
    * <code>contextualSubscriber</code>. Context is captured at the time <code>contextualSubscriber</code> is invoked.</p>
    *
-   * <p>When one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (<code>onSubscribe</code>, <code>onNext</code>,
-   * <code>onError</code>, or <code>onComplete</code>) is invoked on the proxy instance,
+   * <p>When one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (<code>onSubscribe</code>,
+   * <code>onNext</code>, <code>onError</code>, or <code>onComplete</code>) is invoked on the proxy instance,
    * context is first established on the thread that will run the method,
    * then the method of the provided <code>Flow.Subscriber</code> is invoked.
    * Finally, the previous context is restored on the thread, and the result of the
    * <code>Flow.Subscriber</code> is returned to the invoker.</p>
    *
-   * @param <T> the subscriber's item type
+   * @param <T> the subscribed item type
    * @param subscriber instance to contextualize
    * @return contextualized proxy instance that wraps execution of the <code>onSubscribe</code>, <code>onNext</code>,
    * <code>onError</code>, and <code>onComplete</code> methods
    * @since 3.1
    */
   public <T> Flow.Subscriber<T> contextualSubscriber(Flow.Subscriber<T> subscriber);
+  
+  /**
+   * <p>Wraps a {@link java.util.concurrent.Flow.Processor} with context captured from the thread that invokes
+   * <code>contextualProcessor</code>. Context is captured at the time <code>contextualProcessor</code> is invoked.</p>
+   *
+   * <p>When one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (<code>onSubscribe</code>,
+   * <code>onNext</code>, <code>onError</code>, or <code>onComplete</code>) from which {@link java.util.concurrent.Flow.Processor}
+   * extends is invoked on the proxy instance, context is first established on the thread that will run the method,
+   * then the method of the provided <code>Flow.Processor</code> is invoked.
+   * Finally, the previous context is restored on the thread, and the result of the
+   * <code>Flow.Processor</code> is returned to the invoker.</p>
+   *
+   * @param <T> the subscribed item type
+   * @param <R> the published item type
+   * @param processor instance to contextualize
+   * @return contextualized proxy instance that wraps execution of the <code>onSubscribe</code>, <code>onNext</code>,
+   * <code>onError</code>, and <code>onComplete</code> methods
+   * @since 3.1
+   */
+  public <T, R> Flow.Processor<T, R> contextualProcessor(Flow.Processor<T, R> processor);
 
   /**
    * Creates a new contextual object proxy for the input object instance.

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
@@ -221,17 +221,16 @@ public interface ContextService {
    * <p>Wraps a {@link java.util.concurrent.Flow.Subscriber} with context captured from the thread that invokes
    * <code>contextualSubscriber</code>. Context is captured at the time <code>contextualSubscriber</code> is invoked.</p>
    *
-   * <p>When one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (<code>onSubscribe</code>,
+   * <p>Whenever one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (such as <code>onSubscribe</code>,
    * <code>onNext</code>, <code>onError</code>, or <code>onComplete</code>) is invoked on the proxy instance,
    * context is first established on the thread that will run the method,
    * then the method of the provided <code>Flow.Subscriber</code> is invoked.
    * Finally, the previous context is restored on the thread, and the result of the
-   * <code>Flow.Subscriber</code> is returned to the invoker.</p>
+   * <code>Flow.Subscriber</code> method is returned to the invoker.</p>
    *
    * @param <T> the subscribed item type
    * @param subscriber instance to contextualize
-   * @return contextualized proxy instance that wraps execution of the <code>onSubscribe</code>, <code>onNext</code>,
-   * <code>onError</code>, and <code>onComplete</code> methods
+   * @return contextualized proxy instance that wraps execution of all <code>Subscriber</code> methods.
    * @since 3.1
    */
   public <T> Flow.Subscriber<T> contextualSubscriber(Flow.Subscriber<T> subscriber);
@@ -240,18 +239,17 @@ public interface ContextService {
    * <p>Wraps a {@link java.util.concurrent.Flow.Processor} with context captured from the thread that invokes
    * <code>contextualProcessor</code>. Context is captured at the time <code>contextualProcessor</code> is invoked.</p>
    *
-   * <p>When one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (<code>onSubscribe</code>,
+   * <p>Whenever one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (such as <code>onSubscribe</code>,
    * <code>onNext</code>, <code>onError</code>, or <code>onComplete</code>) from which {@link java.util.concurrent.Flow.Processor}
    * extends is invoked on the proxy instance, context is first established on the thread that will run the method,
    * then the method of the provided <code>Flow.Processor</code> is invoked.
    * Finally, the previous context is restored on the thread, and the result of the
-   * <code>Flow.Processor</code> is returned to the invoker.</p>
+   * <code>Flow.Processor</code> method is returned to the invoker.</p>
    *
    * @param <T> the subscribed item type
    * @param <R> the published item type
    * @param processor instance to contextualize
-   * @return contextualized proxy instance that wraps execution of the <code>onSubscribe</code>, <code>onNext</code>,
-   * <code>onError</code>, and <code>onComplete</code> methods
+   * @return contextualized proxy instance that wraps execution of all methods that are inherited from <code>Subscriber</code>.
    * @since 3.1
    */
   public <T, R> Flow.Processor<T, R> contextualProcessor(Flow.Processor<T, R> processor);

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -215,6 +216,25 @@ public interface ContextService {
    * @since 3.0
    */
   public <R> Supplier<R> contextualSupplier(Supplier<R> supplier);
+
+  /**
+   * <p>Wraps a {@link java.util.concurrent.Flow.Subscriber} with context captured from the thread that invokes
+   * <code>contextualSubscriber</code>. Context is captured at the time <code>contextualSubscriber</code> is invoked.</p>
+   *
+   * <p>When one of the methods of the {@link java.util.concurrent.Flow.Subscriber} interface (<code>onSubscribe</code>, <code>onNext</code>,
+   * <code>onError</code>, or <code>onComplete</code>) is invoked on the proxy instance,
+   * context is first established on the thread that will run the method,
+   * then the method of the provided <code>Flow.Subscriber</code> is invoked.
+   * Finally, the previous context is restored on the thread, and the result of the
+   * <code>Flow.Subscriber</code> is returned to the invoker.</p>
+   *
+   * @param <T> the subscriber's item type
+   * @param subscriber instance to contextualize
+   * @return contextualized proxy instance that wraps execution of the <code>onSubscribe</code>, <code>onNext</code>,
+   * <code>onError</code>, and <code>onComplete</code> methods
+   * @since 3.1
+   */
+  public <T> Flow.Subscriber<T> contextualSubscriber(Flow.Subscriber<T> subscriber);
 
   /**
    * Creates a new contextual object proxy for the input object instance.


### PR DESCRIPTION
I'm looking to get feedback on adding these two new APIs to Context Service. After investigation the Flow classes added in Java 9, what I believe would be the most useful addition for Concurrency is providing context on the Flow.Subscriber methods. The new Flow class consists of:

- `Flow.Publisher`
- `Flow.Subscription`
- `Flow.Subscriber`
- `Flow.Processor`

From what I can tell, `Flow.Publisher`'s methods would generally be invoked where context is available, and `Flow.Subscription` doesn't have methods where context would add value. `Flow.Subscriber` is where context could be useful, because it's methods may or may not be called asynchronously. `Flow.Processor` extends `Flow.Publisher` and `Flow.Subscriber`, which is why I provided an API to contextualize it's `Flow.Subscriber` methods.

Let me know your thoughts, or if there's something else we should be considering here.