### PR TITLE
Avoid using hard coded versions in subprojects

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -47,7 +47,7 @@
     </licenses>
 
     <properties>
-        <jakarta.concurrent.api.version>3.1.0-SNAPSHOT</jakarta.concurrent.api.version>
+        <jakarta.concurrent.api.version>${project.version}</jakarta.concurrent.api.version>
         <sigtest.version>1.6</sigtest.version>
         <shrinkwrap.resolver.version>3.2.1</shrinkwrap.resolver.version>
     </properties>


### PR DESCRIPTION
The release build swaps out versions numbers.
If a hard-coded version is missed it causes build errors. 
Related #377