### PR TITLE
document additional limitations if using virtual threads

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ManageableThread.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManageableThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,9 +18,10 @@ package jakarta.enterprise.concurrent;
 
 /**
  *
- * Interface to be implemented by the Jakarta&trade; EE product providers on threads
- * that are created by calling
+ * Interface to be implemented by the Jakarta&trade; EE product providers
+ * on platform threads that are created by calling
  * {@link ManagedThreadFactory#newThread(java.lang.Runnable) }.
+ * Virtual threads do not implement {@code ManageableThread}.
  *
  * @since 1.0
  */

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactory.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,8 +34,9 @@ import java.util.concurrent.ThreadFactory;
  * Component Provider and Deployer identify these requirements and map the
  * resource environment reference appropriately.<p>
  *
- * Threads returned from the {@code newThread()} method should implement the
- * {@link ManageableThread} interface.
+ * Platform threads returned from the {@code newThread()} method should implement the
+ * {@link ManageableThread} interface. Virtual threads do not implement
+ * {@code ManageableThread}.
  *
  * The Runnable task that is allocated to the new thread using the
  * {@link ThreadFactory#newThread(Runnable)} method

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -159,7 +159,9 @@ public @interface ManagedThreadFactoryDefinition {
     String context() default "java:comp/DefaultContextService";
 
     /**
-     * <p>Priority for threads created by this thread factory.</p>
+     * <p>Priority for platform threads created by this thread factory.
+     * Virtual threads always have the priority {@link java.lang.Thread#NORM_PRIORITY}
+     * regardless of this setting.</p>
      *
      * <p>The default is {@link java.lang.Thread#NORM_PRIORITY}.</p>
      *

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1,7 +1,7 @@
 :sectnums:
 = Jakarta Concurrency Specification, Version 3.1
 
-Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 
@@ -2164,8 +2164,8 @@ attributes. See EE.5.8.2 for details.
 The Jakarta EE Product Provider’s responsibilities are as defined in
 EE.5.8.3 and must support the following:
 
-* Threads returned by the `newThread()` method must implement the
-`ManageableThread` interface.
+* Platform threads returned by the `newThread()` method must implement the
+`ManageableThread` interface. Virtual threads do not implement `ManageableThread`.
 * When a `ManagedThreadFactory` instance is stopped, such as when the
 component that created it is stopped or when the application server is
 shutting down, all threads that it has created using the `newThread()`


### PR DESCRIPTION
This pulls updates spec documentation with some additional limitations that will apply if using virtual threads. This includes the inability to use a thread priority other than the default NORM_PRIORITY (5) and that a virtual thread from a ManagedThreadFactory cannot be expected to implement `ManageableThread` because Java restricts creation of virtual threads to its own builders, preventing virtual threads from implementing custom interfaces such as this.