### PR TITLE
document scope for beans, qualifier limitations and example

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Producer;
+import jakarta.inject.Qualifier;
 
 /**
  * <p>Defines a {@link ContextService}
@@ -138,6 +142,14 @@ public @interface ContextServiceDefinition {
      * <p>The default value is an empty list, indicating that this
      * {@code ContextServiceDefinition} does not automatically produce
      * bean instances for any injection points.</p>
+     *
+     * <p>When the qualifiers list is non-empty, the container creates
+     * a {@link ContextService} instance and registers
+     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * The life cycle of the bean aligns with the life cycle of the application
+     * and the bean is not accessible from outside of the application.
+     * Applications must not configure a {@code java:global} {@link #name() name}
+     * if also configuring a non-empty list of qualifiers.</p>
      *
      * <p>Applications can define their own {@link Producer Producers}
      * for {@link ContextService} injection points as long as the

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines a {@link ContextService}
  * to be injected into
  * {@link ContextService} injection points
- * with the specified required {@link #qualifiers()}
+ * including any required {@link Qualifier} annotations specified by {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines a {@link ContextService}
  * to be injected into
  * {@link ContextService} injection points
- * with the specified {@link #qualifiers()}
+ * with the specified required {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>
@@ -133,7 +133,7 @@ public @interface ContextServiceDefinition {
     String name();
 
     /**
-     * <p>List of {@link Qualifier qualifier annotations}.</p>
+     * <p>List of required {@link Qualifier qualifier annotations}.</p>
      *
      * <p>A {@link ContextService} injection point
      * with these qualifier annotations injects a bean that is
@@ -145,7 +145,8 @@ public @interface ContextServiceDefinition {
      *
      * <p>When the qualifiers list is non-empty, the container creates
      * a {@link ContextService} instance and registers
-     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * an {@link ApplicationScoped} bean for it with the specified
+     * required qualifiers and required type of {@code ContextService}.
      * The life cycle of the bean aligns with the life cycle of the application
      * and the bean is not accessible from outside of the application.
      * Applications must not configure a {@code java:global} {@link #name() name}

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines a {@link ManagedExecutorService}
  * to be injected into
  * {@link ManagedExecutorService} injection points
- * with the specified {@link #qualifiers()}
+ * with the specified required {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>
@@ -120,7 +120,7 @@ public @interface ManagedExecutorDefinition {
     String name();
 
     /**
-     * <p>List of {@link Qualifier qualifier annotations}.</p>
+     * <p>List of required {@link Qualifier qualifier annotations}.</p>
      *
      * <p>A {@link ManagedExecutorService} injection point
      * with these qualifier annotations injects a bean that is
@@ -132,7 +132,8 @@ public @interface ManagedExecutorDefinition {
      *
      * <p>When the qualifiers list is non-empty, the container creates
      * a {@link ManagedExecutorService} instance and registers
-     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * an {@link ApplicationScoped} bean for it with the specified
+     * required qualifiers and required type of {@code ManagedExecutorService}.
      * The life cycle of the bean aligns with the life cycle of the application
      * and the bean is not accessible from outside of the application.
      * Applications must not configure a {@code java:global} {@link #name() name}

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.Producer;
 import jakarta.inject.Qualifier;
 
@@ -128,6 +129,14 @@ public @interface ManagedExecutorDefinition {
      * <p>The default value is an empty list, indicating that this
      * {@code ManagedExecutorDefinition} does not automatically produce
      * bean instances for any injection points.</p>
+     *
+     * <p>When the qualifiers list is non-empty, the container creates
+     * a {@link ManagedExecutorService} instance and registers
+     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * The life cycle of the bean aligns with the life cycle of the application
+     * and the bean is not accessible from outside of the application.
+     * Applications must not configure a {@code java:global} {@link #name() name}
+     * if also configuring a non-empty list of qualifiers.</p>
      *
      * <p>Applications can define their own {@link Producer Producers}
      * for {@link ManagedExecutorService} injection points as long as the

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines a {@link ManagedExecutorService}
  * to be injected into
  * {@link ManagedExecutorService} injection points
- * with the specified required {@link #qualifiers()}
+ * including any required {@link Qualifier} annotations specified by {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines a {@link ManagedScheduledExecutorService}
  * to be injected into
  * {@link ManagedScheduledExecutorService} injection points
- * with the specified required {@link #qualifiers()}
+ * including any required {@link Qualifier} annotations specified by {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Producer;
+import jakarta.inject.Qualifier;
 
 /**
  * <p>Defines a {@link ManagedScheduledExecutorService}
@@ -125,6 +129,14 @@ public @interface ManagedScheduledExecutorDefinition {
      * <p>The default value is an empty list, indicating that this
      * {@code ManagedScheduledExecutorDefinition} does not automatically produce
      * bean instances for any injection points.</p>
+     *
+     * <p>When the qualifiers list is non-empty, the container creates
+     * a {@link ManagedScheduledExecutorService} instance and registers
+     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * The life cycle of the bean aligns with the life cycle of the application
+     * and the bean is not accessible from outside of the application.
+     * Applications must not configure a {@code java:global} {@link #name() name}
+     * if also configuring a non-empty list of qualifiers.</p>
      *
      * <p>Applications can define their own {@link Producer Producers}
      * for {@link ManagedScheduledExecutorService} injection points as long as the

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines a {@link ManagedScheduledExecutorService}
  * to be injected into
  * {@link ManagedScheduledExecutorService} injection points
- * with the specified {@link #qualifiers()}
+ * with the specified required {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>
@@ -120,7 +120,7 @@ public @interface ManagedScheduledExecutorDefinition {
     String name();
 
     /**
-     * <p>List of {@link Qualifier qualifier annotations}.</p>
+     * <p>List of required {@link Qualifier qualifier annotations}.</p>
      *
      * <p>A {@link ManagedScheduledExecutorService} injection point
      * with these qualifier annotations injects a bean that is
@@ -132,7 +132,8 @@ public @interface ManagedScheduledExecutorDefinition {
      *
      * <p>When the qualifiers list is non-empty, the container creates
      * a {@link ManagedScheduledExecutorService} instance and registers
-     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * an {@link ApplicationScoped} bean for it with the specified required
+     * qualifiers and required type of {@code ManagedScheduledExecutorService}.
      * The life cycle of the bean aligns with the life cycle of the application
      * and the bean is not accessible from outside of the application.
      * Applications must not configure a {@code java:global} {@link #name() name}

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines {@link ManagedThreadFactory} instances
  * to be injected into
  * {@link ManagedThreadFactory} injection points
- * with the specified required {@link #qualifiers()}
+ * including any required {@link Qualifier} annotations specified by {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -31,7 +31,7 @@ import jakarta.inject.Qualifier;
  * <p>Defines {@link ManagedThreadFactory} instances
  * to be injected into
  * {@link ManagedThreadFactory} injection points
- * with the specified {@link #qualifiers()}
+ * with the specified required {@link #qualifiers()}
  * and registered in JNDI by the container
  * under the JNDI name that is specified in the
  * {@link #name()} attribute.</p>
@@ -118,7 +118,7 @@ public @interface ManagedThreadFactoryDefinition {
     String name();
 
     /**
-     * <p>List of {@link Qualifier qualifier annotations}.</p>
+     * <p>List of required {@link Qualifier qualifier annotations}.</p>
      *
      * <p>A {@link ManagedThreadFactory} injection point
      * with these qualifier annotations injects a bean that is
@@ -130,7 +130,8 @@ public @interface ManagedThreadFactoryDefinition {
      *
      * <p>When the qualifiers list is non-empty, the container creates
      * a {@link ManagedThreadFactory} instance and registers
-     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * an {@link ApplicationScoped} bean for it with the specified
+     * required qualifiers and required type of {@code ManagedThreadFactory}.
      * The life cycle of the bean aligns with the life cycle of the application
      * and the bean is not accessible from outside of the application.
      * Applications must not configure a {@code java:global} {@link #name() name}

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -23,6 +23,10 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Producer;
+import jakarta.inject.Qualifier;
+
 /**
  * <p>Defines {@link ManagedThreadFactory} instances
  * to be injected into
@@ -123,6 +127,14 @@ public @interface ManagedThreadFactoryDefinition {
      * <p>The default value is an empty list, indicating that this
      * {@code ManagedThreadFactoryDefinition} does not automatically produce
      * bean instances for any injection points.</p>
+     *
+     * <p>When the qualifiers list is non-empty, the container creates
+     * a {@link ManagedThreadFactory} instance and registers
+     * an {@link ApplicationScoped} bean for it with the specified qualifiers.
+     * The life cycle of the bean aligns with the life cycle of the application
+     * and the bean is not accessible from outside of the application.
+     * Applications must not configure a {@code java:global} {@link #name() name}
+     * if also configuring a non-empty list of qualifiers.</p>
      *
      * <p>Applications can define their own {@link Producer Producers}
      * for {@link ManagedThreadFactory} injection points as long as the

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -2367,6 +2367,55 @@ ends.
 See section 3.1.8.2.1 for an example of using a `UserTransaction` within a
 task.
 
+=== Beans for Managed Objects
+
+The resource definition annotations, `ContextServiceDefinition`, `ManagedExecutorDefinition`, `ManagedScheduledExecutorDefinition`, and `ManagedThreadFactoryDefinition`, provide a `qualifiers` attribute that the application can optionally configure to specify a list of qualifier annotation classes. Similarly, the corresponding deployment descriptor elements, `<context-service>`, `<managed-executor>`, `<managed-scheduled-executor>`, and `<managed-thread-factory>`, allow `<qualifier>` sub-elements that the application can optionally configure to specify one or more qualifier annotation class names.
+
+When the a non-empty list of qualifier classes is configured for a resource definition, the container creates an instance of the corresponding managed object and registers an `jakarta.enterprise.context.ApplicationScoped` bean for it with the configured qualifiers.
+
+The container also creates a default instance of each managed object type for which the application does not already produce a bean without qualifiers, registering a `jakarta.enterprise.context.ApplicationScoped` bean without qualifiers for the default instance.
+
+The life cycle of these beans aligns with the life cycle of the application component. The configured qualifier annotation classes must be accessible to the application and must not have any attributes without default values. The application must not configure `java:global` names on resource definitions that have a non-empty list of qualifier classes. The container raises an error and does not register the bean if these requirements are not met.
+
+==== Qualifiers Example
+
+In this example, the application configures a single qualifier annotation when defining a `ManagedExecutorService`. The application injects the `ManagedExecutorService` bean by specifying the qualifier annotation on the injection point.
+
+===== Example Qualifier Annotation Class
+
+[source,java]
+----
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface MaxAsync5 {
+}
+----
+
+===== Example usage of Qualifier Annotation
+
+[source,java]
+----
+@ManagedExecutorDefinition(
+        name = "java:comp/concurrent/MyExecutor",
+        qualifiers = Max5Async.class,
+        maxAsync = 5)
+public class MyServlet extends HttpServlet {
+   @Inject
+   @Max5Async
+   ManagedExecutorService executor;
+
+   ...
+}
+----
+
 == Thread Context Providers
 
 The `ThreadContextProvider` SPI standardizes the interaction between

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -2371,7 +2371,7 @@ task.
 
 The resource definition annotations, `ContextServiceDefinition`, `ManagedExecutorDefinition`, `ManagedScheduledExecutorDefinition`, and `ManagedThreadFactoryDefinition`, provide a `qualifiers` attribute that the application can optionally configure to specify a list of required qualifier annotation classes. Similarly, the corresponding deployment descriptor elements, `<context-service>`, `<managed-executor>`, `<managed-scheduled-executor>`, and `<managed-thread-factory>`, allow `<qualifier>` sub-elements that the application can optionally configure to specify one or more required qualifier annotation class names.
 
-When a non-empty list of qualifier classes is configured for a resource definition, the container creates an instance of the corresponding managed object and registers an `jakarta.enterprise.context.ApplicationScoped` bean for it with the configured qualifiers.
+When a non-empty list of qualifier classes is configured for a resource definition, the container creates an instance of the corresponding managed object and registers a `jakarta.enterprise.context.ApplicationScoped` bean for it with the configured qualifiers.
 
 The container also creates a default instance of each managed object type for which the application does not already produce a bean without required qualifiers, registering a `jakarta.enterprise.context.ApplicationScoped` bean without qualifiers for the default instance.
 

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -2371,7 +2371,7 @@ task.
 
 The resource definition annotations, `ContextServiceDefinition`, `ManagedExecutorDefinition`, `ManagedScheduledExecutorDefinition`, and `ManagedThreadFactoryDefinition`, provide a `qualifiers` attribute that the application can optionally configure to specify a list of required qualifier annotation classes. Similarly, the corresponding deployment descriptor elements, `<context-service>`, `<managed-executor>`, `<managed-scheduled-executor>`, and `<managed-thread-factory>`, allow `<qualifier>` sub-elements that the application can optionally configure to specify one or more required qualifier annotation class names.
 
-When the a non-empty list of qualifier classes is configured for a resource definition, the container creates an instance of the corresponding managed object and registers an `jakarta.enterprise.context.ApplicationScoped` bean for it with the configured qualifiers.
+When a non-empty list of qualifier classes is configured for a resource definition, the container creates an instance of the corresponding managed object and registers an `jakarta.enterprise.context.ApplicationScoped` bean for it with the configured qualifiers.
 
 The container also creates a default instance of each managed object type for which the application does not already produce a bean without required qualifiers, registering a `jakarta.enterprise.context.ApplicationScoped` bean without qualifiers for the default instance.
 

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -350,7 +350,7 @@ interfaces provide.
 The application uses the
 `jakarta.enterprise.concurrent.ManagedExecutorDefinition` annotation
 to define instances of `ManagedExecutorService` and enumerate the
-qualifiers for `ManagedExecutorService` injection points
+required qualifiers for `ManagedExecutorService` injection points
 that are to receive a `ManagedExecutorService` bean
 that is produced by the `ManagedExecutorDefinition`.
 
@@ -1066,7 +1066,7 @@ that these interfaces provide.
 The application uses the
 `jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition` annotation
 to define instances of `ManagedScheduledExecutorService` and enumerate the
-qualifiers for `ManagedScheduledExecutorService` injection points
+required qualifiers for `ManagedScheduledExecutorService` injection points
 that are to receive a `ManagedScheduledExecutorService` bean
 that is produced by the `ManagedScheduledExecutorDefinition`.
 
@@ -1520,7 +1520,7 @@ a ContextService instance to create contextual object proxies.
 The application uses the
 `jakarta.enterprise.concurrent.ContextServiceDefinition` annotation
 to define instances of `ContextService` and enumerate the
-qualifiers for `ContextService` injection points
+required qualifiers for `ContextService` injection points
 that are to receive a `ContextService` bean
 that is produced by the `ContextServiceDefinition`.
 
@@ -1982,7 +1982,7 @@ manageable threads.
 The application uses the
 `jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition` annotation
 to define instances of `ManagedThreadFactory` and enumerate the
-qualifiers for `ManagedThreadFactory` injection points
+required qualifiers for `ManagedThreadFactory` injection points
 that are to receive a `ManagedThreadFactory` bean
 that is produced by the `ManagedThreadFactoryDefinition`.
 
@@ -2369,11 +2369,11 @@ task.
 
 === Beans for Managed Objects
 
-The resource definition annotations, `ContextServiceDefinition`, `ManagedExecutorDefinition`, `ManagedScheduledExecutorDefinition`, and `ManagedThreadFactoryDefinition`, provide a `qualifiers` attribute that the application can optionally configure to specify a list of qualifier annotation classes. Similarly, the corresponding deployment descriptor elements, `<context-service>`, `<managed-executor>`, `<managed-scheduled-executor>`, and `<managed-thread-factory>`, allow `<qualifier>` sub-elements that the application can optionally configure to specify one or more qualifier annotation class names.
+The resource definition annotations, `ContextServiceDefinition`, `ManagedExecutorDefinition`, `ManagedScheduledExecutorDefinition`, and `ManagedThreadFactoryDefinition`, provide a `qualifiers` attribute that the application can optionally configure to specify a list of required qualifier annotation classes. Similarly, the corresponding deployment descriptor elements, `<context-service>`, `<managed-executor>`, `<managed-scheduled-executor>`, and `<managed-thread-factory>`, allow `<qualifier>` sub-elements that the application can optionally configure to specify one or more required qualifier annotation class names.
 
 When the a non-empty list of qualifier classes is configured for a resource definition, the container creates an instance of the corresponding managed object and registers an `jakarta.enterprise.context.ApplicationScoped` bean for it with the configured qualifiers.
 
-The container also creates a default instance of each managed object type for which the application does not already produce a bean without qualifiers, registering a `jakarta.enterprise.context.ApplicationScoped` bean without qualifiers for the default instance.
+The container also creates a default instance of each managed object type for which the application does not already produce a bean without required qualifiers, registering a `jakarta.enterprise.context.ApplicationScoped` bean without qualifiers for the default instance.
 
 The life cycle of these beans aligns with the life cycle of the application component. The configured qualifier annotation classes must be accessible to the application and must not have any attributes without default values. The application must not configure `java:global` names on resource definitions that have a non-empty list of qualifier classes. The container raises an error and does not register the bean if these requirements are not met.
 


### PR DESCRIPTION
We need to add more information to the Concurrency spec on the new pattern with qualifiers, such as what scope the injected bean should be.  ApplicationScoped seems appropriate given other requirements in the spec to make the life cycles of concurrency managed objects align with the application's life cycle.  We should also include a short example qualifier/inject and document any other limitations, such as that the qualifier annotation will either need to have no attributes or have all attributes defaulted.