### PR TITLE
Update specification copyright year to 2024

### DIFF
--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -9,7 +9,7 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-Copyright (c) 2018,2022 Eclipse Foundation.
+Copyright (c) 2018,2024 Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 


### PR DESCRIPTION
The Jakarta Concurrency specification document still shows 2022 as the copyright year (which would have been the case for Concurrency 3.0). This pulls updates it to 2024.