### PR TITLE
Various grammar and formatting fixes to the specification document

### DIFF
--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -188,7 +188,7 @@ image:2.jpg[image]
 
 Container context and management constructs are propagated to component
 business logic at runtime using various invocation points on well-known
-interfaces. These invocation points or callback methods, here-by known
+interfaces. These invocation points or callback methods, hereby known
 as "tasks" will be referred to throughout the specification:
 
 * `java.util.concurrent.Callable`
@@ -438,7 +438,7 @@ annotation can be used in the Servlet code.
 Using the description for documenting the configuration
 attributes of the managed object is optional. The format used here is
 only an example. Future revisions of Jakarta EE specifications may
-formalize usages such as this._
+formalize usages such as this.
 ====
 
 [source,xml]
@@ -460,7 +460,7 @@ formalize usages such as this._
 ====== Task Definition – Reporter Task
 
 The task itself simply uses a resource-reference to a JDBC data source,
-and uses a connect/use/close pattern when invoking the Datasource.
+and uses a connect/use/close pattern when invoking the data source.
 [source,java]
 ----
 public class ReporterTask implements Runnable {
@@ -480,7 +480,7 @@ public void run() {
   }
 }
 
-Datasource ds = …;
+DataSource ds = …;
 
 void runTransactionReport() {
   try (Connection con = ds.getConnection(); ...) {
@@ -524,7 +524,7 @@ public class AppServlet extends HTTPServlet implements Servlet {
     // the status of the report.
     ...
 
-    // Tell the user that the report has been submitted. +
+    // Tell the user that the report has been submitted.
     ... 
   } 
 }
@@ -549,7 +549,7 @@ annotation can be used in the Servlet code:
 Using the description for documenting the configuration
 attributes of the managed object is optional. The format used here is
 only an example. Future revisions of Jakarta EE specifications may
-formalize usages such as this._
+formalize usages such as this.
 ====
 
 [source,xml]
@@ -793,9 +793,9 @@ Work Queue: 15
 Capacity:
 
 |Reject Policy a|
- Abort
+* [x] Abort
 
-Retry and Abort
+* [ ] Retry and Abort
 
 |===
 
@@ -828,9 +828,9 @@ Work Queue: 5
 Capacity:
 
 |Reject Policy a|
-Abort
+* [ ] Abort
 
-Retry and Abort
+* [ ] Retry and Abort
 
 |===
 
@@ -865,9 +865,9 @@ Work Queue: 100
 Capacity:
 
 |Reject Policy a|
-Abort
+* [ ] Abort
 
-Retry and Abort
+* [ ] Retry and Abort
 
 |===
 
@@ -1126,9 +1126,9 @@ illustrates how the component can describe and utilize a
 ===== Usage Example 
 
 In this example, an application component wants to use a timer to
-periodically write in- memory events to a database log.
+periodically write in-memory events to a database log.
 
-The attributes of the `ManagedScheduledExecutorService` reference is
+The attributes of the `ManagedScheduledExecutorService` reference are
 documented using the `<description>` tag within the deployment descriptor
 of the application component and later mapped by the Deployer.
 
@@ -1151,7 +1151,7 @@ annotation can be used in the Servlet code.
 Using the description for documenting the configuration
 attributes of the managed object is optional. The format used here is
 only an example. Future revisions of Jakarta EE specifications may
-formalize usages such as this._
+formalize usages such as this.
 ====
 
 [source,xml]
@@ -1173,7 +1173,7 @@ formalize usages such as this._
 ====== Task Definition 
 
 The task itself simply uses a resource-reference to a JDBC data source,
-and uses a connect/use/close pattern when invoking the Datasource.
+and uses a connect/use/close pattern when invoking the data source.
 
 [source,java]
 ----
@@ -1285,7 +1285,7 @@ component’s resource environment reference.
 * *Context*: A reference to a ContextService instance (see section 3.3).
 The context service can be used to define the context to propagate to
 the threads when running tasks. Having multiple ContextService
-instances, each with a different policy may be desirable for some
+instances, each with a different policy, may be desirable for some
 implementations. If both Context and ThreadFactory attributes are
 specified, the Context attribute of the ThreadFactory configuration
 should be ignored.
@@ -1320,7 +1320,7 @@ This example describes a typical configuration for a
 timers can run simultaneously and are considered hung if they have run
 more than 5 seconds. An executor such as this can be shared between
 applications and is designed to run very short-duration tasks, for
-example, marking a transaction to rollback after a timeout.
+example, marking a transaction to roll back after a timeout.
 ====
 
 [cols=",",]
@@ -1331,9 +1331,9 @@ example, marking a transaction to rollback after a timeout.
 |Context: |concurrent/ctx/AllContexts
 |Thread Factory: |concurrent/tf/normal
 |Thread Use: a|
- Pooled
+* [x] Pooled
 
-Daemon
+* [ ] Daemon
 
 |Hung Task Threshold |5000 ms
 |Pool Info: a|
@@ -1344,9 +1344,9 @@ Max Size: 10
 Keep Alive: 3000 ms
 
 |Reject Policy a|
-Abort
+* [ ] Abort
 
-Retry and Abort
+* [ ] Retry and Abort
 
 |===
 
@@ -1630,7 +1630,7 @@ This example refers to a `ContextService` and a `ManagedThreadFactory`.
 Using the description for documenting the configuration
 attributes of the managed object is optional. The format used here is
 only an example. Future revisions of Jakarta EE specifications may
-formalize usages such as this._
+formalize usages such as this.
 ====
 
 [source,xml]
@@ -1672,7 +1672,7 @@ formalize usages such as this._
 ====== Task Definition 
 
 This task logs the request in a database, which requires the local
-namespace in order to locate the correct Datasource. It also utilizes
+namespace in order to locate the correct `DataSource`. It also utilizes
 the Java Authentication and Authorization API (JAAS) to retrieve the
 user's identity from the current thread in order to audit access to the
 credit report.
@@ -1841,11 +1841,11 @@ propagated.
 |Name: |All Contexts
 |JNDI Name: |Concurrent/cs/AllContexts
 |Context Info: a|
- Security
+* [x] Security
 
- Locale
+* [x] Locale
 
- Custom
+* [x] Custom
 
 |===
 
@@ -1859,11 +1859,11 @@ propagated.
 |Name: |OLTP Contexts
 |JNDI Name: |Concurrent/cs/OLTPContexts
 |Context Info: a|
- Security
+* [x] Security
 
-Locale
+* [ ] Locale
 
- Custom
+* [x] Custom
 
 |===
 ##Table : OLTP Contexts Configuration Example
@@ -1908,7 +1908,7 @@ demarcation using the `jakarta.transaction.UserTransaction` interface, which
 is described in the Jakarta Transactions specification. By default,
 proxy methods suspend any transactional context on the thread and allow
 components to manually control global transaction demarcation
-boundaries. Context objects may optionally begin, commit, and rollback a
+boundaries. Context objects may optionally begin, commit, and roll back a
 transaction. See EE.4 for details on transaction management in Jakarta EE.
 
 By using an execution property when creating the contextual proxy
@@ -2038,7 +2038,7 @@ In this example, an application component uses a background daemon task
 to dump in-memory events to a database log, similar to the timer usage
 example in section 3.2.1.1.
 
-The attributes of the `ManagedThreadFactory` reference is documented using
+The attributes of the `ManagedThreadFactory` reference are documented using
 the `<description>` tag within the deployment descriptor of the
 application component and later mapped by the Deployer.
 
@@ -2061,7 +2061,7 @@ configuration attributes (see section 3.4.4.2). Alternatively, the
 Using the description for documenting the configuration
 attributes of the managed object is optional. The format used here is
 only an example. Future revisions of Jakarta EE specifications may
-formalize usages such as this._
+formalize usages such as this.
 ====
 
 [source,xml]
@@ -2086,7 +2086,7 @@ formalize usages such as this._
 ====== Task Definition 
 
 The task itself simply uses a resource-reference to a JDBC data source,
-and uses a connect/use/close pattern when invoking the Datasource.
+and uses a connect/use/close pattern when invoking the data source.
 
 [source,java]
 ----
@@ -2177,7 +2177,7 @@ method are interrupted. Calls to the `isShutdown()` method in the
 [NOTE]
 ====
 The intent is to prevent access to components that are no
-longer available._
+longer available.
 ====
 
 * Threads that are created by a `ManagedThreadFactory` instance but are
@@ -2228,7 +2228,7 @@ component’s resource environment reference.
 * *Context*: A reference to a `ContextService` instance (see section 3.3).
 The context service can be used to define the context to propagate to
 the threads when running tasks. Having multiple `ContextService`
-instances, each with a different policy may be desirable for some
+instances, each with a different policy, may be desirable for some
 implementations.
 * *Priority*: The priority to assign to the thread (the higher the
 number, the higher the priority). See the `java.lang.Thread` Javadoc for


### PR DESCRIPTION
The pull contains various grammar and formatting fixes to the Concurrency specification document.
One category of formatting errors is with the use of checked and empty checkboxes, with the former rendering improperly (as a square with a question mark inside) and the latter not showing at all.