### PR TITLE
Re-enable java 17 CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     # TODO update once 25-ea is available
     strategy:
       matrix:
-        java-version: [ '21' ]
+        java-version: [ '17', '21' ]
 
     runs-on: ubuntu-latest
 

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorService.java
@@ -66,8 +66,8 @@ import java.util.function.Supplier;
  * }
  * </pre>
  *
- * Tasks can optionally provide an {@link ManagedTaskListener} to receive
- * notifications of lifecycle events, through the use of {@link ManagedTask}
+ * Tasks can optionally provide a {@link ManagedTaskListener} to receive
+ * notifications of lifecycle events, through the use of the {@link ManagedTask}
  * interface.
  * <p>
  * Example:


### PR DESCRIPTION
Changes the CI to run on both Java 17 and 21, following the change to Jakarta EE 11 to support both Java versions.
Minor typo fixes in ManagedExecutorService Javadoc