### PR TITLE
Remove override via application.xml test

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/common/qualifiers/OverwrittenQualifier4.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/common/qualifiers/OverwrittenQualifier4.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.common.qualifiers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+/**
+ * A qualifier that is used to identify concurrent resources for injection.
+ * This qualifier is sometimes overwritten via config.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface OverwrittenQualifier4 {
+    
+    class Literal extends AnnotationLiteral<OverwrittenQualifier4> implements OverwrittenQualifier4 {
+        private static final long serialVersionUID = 1L;
+        
+        private static Literal inst = new Literal();
+        
+        public static Literal get() {
+            return inst;
+        }
+    }
+    
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationFullTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationFullTests.java
@@ -93,7 +93,7 @@ public class AnnotationFullTests extends TestClient {
     }
     
     @Assertion(id = "GIT:404", strategy = "Tests injection of managed thread factory defined in an annotation with qualifier(s).")
-    public void testAnnoDefinedManagedThreadFactoryQualifers() {
+    public void testAnnoDefinedManagedThreadFactoryQualifersFull() {
         runTest(baseURL, testname);
     }
 

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationServlet.java
@@ -39,6 +39,7 @@ import ee.jakarta.tck.concurrent.common.context.StringContext;
 import ee.jakarta.tck.concurrent.common.qualifiers.CustomQualifier1;
 import ee.jakarta.tck.concurrent.common.qualifiers.CustomQualifier2;
 import ee.jakarta.tck.concurrent.common.qualifiers.InvalidQualifier3;
+import ee.jakarta.tck.concurrent.common.qualifiers.OverwrittenQualifier4;
 import ee.jakarta.tck.concurrent.framework.TestServlet;
 import jakarta.annotation.Resource;
 import jakarta.ejb.EJB;
@@ -76,7 +77,7 @@ import jakarta.transaction.UserTransaction;
 @ManagedThreadFactoryDefinition(
         name = "java:app/concurrent/ThreadFactoryE",
         context = "java:app/concurrent/ContextE",
-        qualifiers = InvalidQualifier3.class, // overridden via web.xml
+        qualifiers = OverwrittenQualifier4.class, // overwritten via web.xml
         priority = 6
         )
 @WebServlet("/AnnotationServlet")
@@ -245,8 +246,8 @@ public class AnnotationServlet extends TestServlet {
                     "Annotation defined managedThreadFactory with qualifiers could not be found via @Resource."),
             () -> assertEquals(lookupMTFE.newThread(NOOP_RUNNABLE).getPriority(), resourceMTFE.newThread(NOOP_RUNNABLE).getPriority(),
                     "The managedThreadFactory from resource injection and lookup did not have the same priority."),
-            () -> assertTrue(CDI.current().select(ManagedThreadFactory.class, InvalidQualifier3.Literal.get()).isResolvable(),
-                    "A managedThreadFactory was not satisfied with a required qualifier that was not overriden by a deployment descriptor.")
+            () -> assertTrue(CDI.current().select(ManagedThreadFactory.class, OverwrittenQualifier4.Literal.get()).isResolvable(),
+                    "A managedThreadFactory was not satisfied with a required qualifier that was not overwritten by a deployment descriptor.")
         );
     }
 
@@ -265,8 +266,8 @@ public class AnnotationServlet extends TestServlet {
                     "Annotation defined managedThreadFactory with no qualifiers could not be found via @Resource."),
             () -> assertEquals(lookupMTFE.newThread(NOOP_RUNNABLE).getPriority(), resourceMTFE.newThread(NOOP_RUNNABLE).getPriority(),
                     "The managedThreadFactory from resource injection and lookup did not have the same priority."),
-            () -> assertTrue(CDI.current().select(ManagedThreadFactory.class, InvalidQualifier3.Literal.get()).isUnsatisfied(),
-                    "A managedThreadFactory was satisfied with a required qualifier that should have been overriden by the deployment descriptor.")
+            () -> assertTrue(CDI.current().select(ManagedThreadFactory.class, OverwrittenQualifier4.Literal.get()).isUnsatisfied(),
+                    "A managedThreadFactory was satisfied with a required qualifier that should have been overwritten by the deployment descriptor.")
         );
     }
 

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationWebTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationWebTests.java
@@ -79,7 +79,7 @@ public class AnnotationWebTests extends TestClient {
     }
     
     @Assertion(id = "GIT:404", strategy = "Tests injection of managed thread factory defined in an annotation with qualifier(s).")
-    public void testAnnoDefinedManagedThreadFactoryQualifers() {
+    public void testAnnoDefinedManagedThreadFactoryQualifersWeb() {
         runTest(baseURL, testname);
     }
 

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/application.xml
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/application.xml
@@ -32,9 +32,4 @@
     <ejb>AnnotationTests_ejb.jar</ejb>
   </module>
 
-  <managed-thread-factory>
-    <name>java:app/concurrent/ThreadFactoryE</name>
-    <qualifier></qualifier> <!-- Overrides qualifiers defined in ManagedThreadFactoryDefinition -->
-  </managed-thread-factory>
-
 </application>


### PR DESCRIPTION
When writing tests for `qualifier` I wrote a test that is invalid.

Based on the Concurrency javadoc:
https://github.com/jakartaee/concurrency/blob/357c45e284e1a44783209608e92c8ed27e1705ef/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java#L93-L99

I assumed that meant that a deployment descriptor in `application.xml` would merge/override values defined on the class annotation `@ManagedThreadFactoryDefinition`. 

This was the wrong assumption based on the platform spec: 
https://github.com/jakartaee/platform/blob/29bf7cc3266097d3b68d8d849ccd01eefbae9a1b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc?plain=1#L1069-L1081

Which seems to indicate that `metadata-complete` is what defines whether or not merging should happen between deployment descriptor and annotation defined resources.

It wouldn't make sense for application.xml to have a metadata-complete attribute since there are no packages/classes directly in the application EAR (there are only modules and libraries).
The schema backs this up by not having a metadata-complete attribute for application.xml and therefore we can infer that any resource defined in application.xml is complete and will never be merged, making this test invalid. 