### PR TITLE
Update workflows and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,10 +1,10 @@
 name: Bug Report
-description: Jakarta Concurrency Bug Report
+description: Report a mistake or inconsistency in the specification code or documentation text.
 title: "[Bug]: "
 labels: ["bug"] #Verified - label exists
 body:
   - type: markdown
-    attributes: 
+    attributes:
       value: |
         > Report a mistake or inconsistency in the specification code, TCK tests, or documentation text.
         > If error is related to a TCK test after release, then use the TCK Challenge template instead.
@@ -12,9 +12,9 @@ body:
     id: version
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Specification Version
-      description: What version of the Concurrency Spec are you running using? 
+      description: What version of the Concurrency Spec are you running using?
       options:
         - 3.1.0-M1
         - 3.0.2

--- a/.github/ISSUE_TEMPLATE/clarification.yml
+++ b/.github/ISSUE_TEMPLATE/clarification.yml
@@ -1,5 +1,5 @@
 name: Clarification
-description: Jakarta Concurrency Clarification
+description: Request that some aspect of the specification be clarified. 
 title: "[clarification]: "
 labels: ["question"] #Verified - label exists
 body:
@@ -13,7 +13,7 @@ body:
       required: true
     attributes: 
       label: Specification
-      description: What specification is the clarification related to? Provide a link to the API class or SPEC document section. 
+      description: What specification / api is the clarification related to? Provide a link to the API class or SPEC document section. 
       placeholder: |
         ex. [Aborted Exception](https://github.com/jakartaee/concurrency/blob/master/api/src/main/java/jakarta/enterprise/concurrent/AbortedException.java#L22)
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -34,6 +34,7 @@ body:
           #### Prepare
             - [X] Open this issue.
             - [ ] Complete outstanding work
+            - [ ] (Update TCK Signatures to capture API changes)[https://github.com/jakartaee/concurrency/actions/workflows/release.yml]
           #### Stage release
             - [ ] [Build and stage artifacts to staging repository](https://ci.eclipse.org/cu/view/Release/job/concurrency_api_1-build-and-stage/)
             - [ ] [Build and stage the TCK distribution artifact to download.eclipse.org](https://ci.eclipse.org/cu/view/Release/job/concurrency_tck_1-build-and-stage/)

--- a/.github/ISSUE_TEMPLATE/tck-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/tck-challenge.yml
@@ -4,7 +4,7 @@ title: "[TCK Challenge]: "
 labels: ["challenge"] #Verified - label exists
 body:
   - type: markdown
-    attributes: 
+    attributes:
       value: |
         > Before submitting a TCK Challenge to the Jakarta Concurrency community please read and be familiar with the 
         > [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.
@@ -12,7 +12,7 @@ body:
     id: specification
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Specification
       description: What specification is the challenge related to? Provide a link to the API class or SPEC document section. 
       placeholder: |
@@ -21,7 +21,7 @@ body:
     id: assertion
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Assertion
       description: What assertion is the challenge related to? Provide a link to the assertion description
       placeholder: |
@@ -30,9 +30,9 @@ body:
     id: version
     validations:
       required: true
-    attributes: 
+    attributes:
       label: TCK Version
-      description: What version of the TCK are you running against? 
+      description: What version of the TCK are you running against?
       options:
         - 3.1.0-M1
         - 3.0.2
@@ -43,7 +43,7 @@ body:
     id: implementation
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Implementation being tested
       description: What implementation is being tested? Include name of company/organization
       placeholder: |
@@ -52,10 +52,10 @@ body:
     id: challengeType
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Challenge Scenario
-      description: Which of the following scenarios best match this challenge? 
-      options: 
+      description: Which of the following scenarios best match this challenge?
+      options:
         - Claims that a test assertion conflicts with the specification.
         - Claims that a test asserts requirements over and above that of the specification.
         - Claims that an assertion of the specification is not sufficiently implementable.
@@ -84,5 +84,5 @@ body:
         Please search to see if a challenge already exists, or has been approved, that matches your challenge.
         https://github.com/jakartaee/concurrency/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Achallenge
       options:
-      - label: I have searched the existing issues
-        required: true
+        - label: I have searched the existing issues
+          required: true

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -1,5 +1,5 @@
 name: Use Case
-description: Jakarta Concurrency Use Case
+description: Describe a new use case for the specification. 
 title: "[Use Case]: "
 labels: ["enhancement"] #Verified - label exists
 body:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@
 name: Java CI with Maven
 
 on:
-  pull_request:
-    branches: [ "main" ]
   push:
+    branches: [ "main" ]
+  pull_request:
     branches: [ "main" ]
 
 permissions:
@@ -30,5 +30,5 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
         cache: maven
-    - name: Build API, SPEC, and TCK
-      run: mvn -B install --file pom.xml
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # This workflow will run when a release is created, and automatically update GitHub issue templates
 
-name: Release published
+name: GitHub Release
 
 on:
   release:
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
+    - name: checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: 'main' # Otherwise, this action will checkout the tag that was created during publishing
     - name: Create branch
       id: checkout
       run: .github/scripts/checkout.sh update-templates-${{ github.sha }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,9 @@ jobs:
       id: checkout
       run: .github/scripts/checkout.sh update-generated-files-${{ github.sha }}
     - name: Generate signatures
-      run: mvn package -Psignature-generation --file tck/pom.xml
+      run: |
+        mvn install --file api/pom.xml
+        mvn package -Psignature-generation --file tck/pom.xml
     ## Add any other automated update steps here
     - name: Needs updates
       id: update
@@ -40,7 +42,7 @@ jobs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
 
-        git add -u
+        git add tck/src/main/resources/
         git commit -m "Update generated files ${{ matrix.java-version }}"
         git push origin update-generated-files-${{ github.sha }}
 


### PR DESCRIPTION
This PR updates the following: 

- Issue template descriptions to be more specific to help users choose which template to use.
- General formatting of issue templates
- Switch CI workflow from `install` to `package` for performance
- Ensure release workflow uses correct branch
- Ensure update workflow runs and only commits files we expect to be changed (for better security)

This PR should likely be merged after https://github.com/jakartaee/concurrency/pull/426 to avoid merge conflicts. 