### PR TITLE
Add scheduled async tests

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
@@ -196,7 +196,7 @@ public @interface Asynchronous {
      * attempts to start the next execution of the method at 8:03 AM.</p>
      *
      * <p>Scheduled asynchronous methods are treated similar to other scheduled
-     * tasks in that they are not subject to {@code max-async} constaints of
+     * tasks in that they are not subject to {@code max-async} constraints of
      * {@code managed-scheduled-executor-definition} and
      * {@code managed-executor-definition} and the corresponding
      * {@link ManagedScheduledExecutorDefinition#maxAsync()} and

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/AppBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/AppBean.java
@@ -15,6 +15,7 @@
  */
 package ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -24,15 +25,23 @@ import java.util.concurrent.Exchanger;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
 import ee.jakarta.tck.concurrent.common.context.IntContext;
 import ee.jakarta.tck.concurrent.common.context.StringContext;
 import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.Schedule;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class AppBean {
+    
+    private static final Logger log = Logger.getLogger(AppBean.class.getCanonicalName());
+    
     private static final long MAX_WAIT_SECONDS = TimeUnit.MINUTES.toSeconds(2);
+    
+    // Asynchronous Tests
 
     @Asynchronous(executor = "java:module/concurrent/ExecutorB")
     public CompletionStage<String> addStringContextAndWait(final BlockingQueue<String> queue, final CountDownLatch blocker) {
@@ -69,5 +78,189 @@ public class AppBean {
             future.completeExceptionally(x);
         }
         return future;
+    }
+    
+    // Scheduled Asynchronous Tests
+    public static enum RETURN {
+            NULL, // Never completes
+            COMPLETE_EXCEPTIONALLY, // Completes with exception
+            COMPLETE_RESULT, // Completes with result
+            INCOMPLETE, // Returns future that is not complete
+            THROW_EXCEPTION; // Method throws exception
+            
+            private String message = "";
+            
+            public RETURN withMessage(final String m) {
+                this.message = m;
+                return this;
+            }
+            
+            public String getMessage() {
+                return message;
+            }
+    }
+    
+    /**
+     * A scheduled async method that runs every 5 seconds
+     *
+     * @param runs - how many times to run before returning
+     * @param type - how this method should return (successfully / incomplete / exceptionally)
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return A result or exception
+     */
+    @Asynchronous(runAt = @Schedule(cron = "*/5 * * * * *"))
+    public CompletableFuture<Integer> scheduledEvery5seconds(final int runs, final RETURN type, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery5seconds method " + count + "/" + runs + " (Returning: " + type.toString() + ")");
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Integer> future = Asynchronous.Result.getFuture();
+        
+        switch (type) {
+        case NULL: //Never stop executions
+            return null;
+        case COMPLETE_EXCEPTIONALLY:
+            future.completeExceptionally(new Exception(type.getMessage()));
+            break;
+        case COMPLETE_RESULT:
+            future.complete(count);
+            break;
+        case INCOMPLETE:
+            break; //never complete future
+        case THROW_EXCEPTION:
+            throw new RuntimeException(type.getMessage());
+        default:
+            break;
+        }
+        
+        return future;
+    }
+    
+    @Asynchronous(runAt = @Schedule(cron = "*/3 * * * * *"))
+    public void scheduledEvery3SecondsVoidReturn(final int runs, final RETURN type, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3SecondsVoidReturn method " + count + "/" + runs + " (Returning: " + type.toString() + ")");
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Void> future = Asynchronous.Result.getFuture();
+        
+        switch (type) {
+        case COMPLETE_EXCEPTIONALLY:
+            future.completeExceptionally(new Exception(type.getMessage()));
+            break;
+        case COMPLETE_RESULT:
+            future.complete(null);
+            break;
+        case THROW_EXCEPTION:
+            throw new RuntimeException(type.getMessage());
+        default:
+            break;
+        }
+    }
+    
+    /**
+     * A scheduled async method that runs every 3 seconds, but takes 5 seconds to complete
+     *
+     * @param runs - how many times to run before returning
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return The number of runs completed
+     */
+    @Asynchronous(runAt = @Schedule(cron = "*/3 * * * * *"))
+    public CompletableFuture<Integer> scheduledEvery3SecondsTakes5Seconds(final int runs, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3SecondsTakes5Seconds method " + count + "/" + runs);
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            
+            try {
+                Thread.sleep(Duration.ofSeconds(5).toMillis());
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Thread was interrupted while waiting", e);
+            }
+            
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Integer> future = Asynchronous.Result.getFuture();
+        future.complete(count);
+        
+        return future;
+    }
+    
+    /**
+     * A scheduled async method that runs every 3 seconds
+     * Uses executor = "java:module/concurrent/ExecutorB" with max-async = 1
+     *
+     * @param runs - how many times to run before returning
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return completed future of IntContext
+     */
+    @Asynchronous(executor = "java:module/concurrent/ExecutorB", runAt = @Schedule(cron = "*/3 * * * * *"))
+    public CompletableFuture<Integer> scheduledEvery3Seconds(final int runs, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3Seconds method " + count + "/" + runs);
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Integer> future = Asynchronous.Result.getFuture();
+        future.complete(IntContext.get());
+        
+        return future;
+    }
+    
+    /**
+     * A scheduled async method that runs every 3 seconds and every minute
+     * Uses executor = "java:app/concurrent/ExecutorA" with max-async = 1
+     *
+     * @param runs - how many times to run before returning
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return completed future of StringContext
+     */
+    @Asynchronous(executor = "java:module/concurrent/ExecutorB", runAt = {
+            @Schedule(cron = "*/3 * * * * *"),
+            @Schedule(cron = "0 * * * * *")
+    })
+    public CompletableFuture<String> scheduledEvery3SecondsAnd1Minute(final int runs, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3SecondsAnd1Minute method " + count + "/" + runs);
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<String> future = Asynchronous.Result.getFuture();
+        future.complete(StringContext.get());
+        
+        return future;
+    }
+    
+    /**
+     * A scheduled async method that should not run due to invalid configuration
+     */
+    @Asynchronous(executor = "java:app/concurrent/INVALID", runAt = @Schedule(cron = "*/3 * * * * *"))
+    public CompletableFuture<String> scheduledInvalidExecutor() {
+        throw new UnsupportedOperationException("Should not be able to execute with invalid executor");
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionFullTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionFullTests.java
@@ -32,6 +32,7 @@ import ee.jakarta.tck.concurrent.framework.URLBuilder;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Assertion;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Challenge;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common.PACKAGE;
+import ee.jakarta.tck.concurrent.framework.junit.anno.Debug;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Full;
 import ee.jakarta.tck.concurrent.framework.junit.anno.TestName;
 import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextServiceDefinitionBean;
@@ -40,6 +41,7 @@ import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextSer
 import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
 
 @Full
+@Debug //TODO remove after testing
 @RunAsClient // Requires client testing due to multiple servlets and annotation configuration
 public class ManagedExecutorDefinitionFullTests extends TestClient {
 
@@ -151,5 +153,46 @@ public class ManagedExecutorDefinitionFullTests extends TestClient {
     public void testManagedExecutorDefinitionDefaults() {
         runTest(baseURL, testname);
     }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when future is completed.")
+    public void testScheduledAsynchCompletedFuture() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when a non-null result is returned.")
+    public void testScheduledAsynchCompletedResult() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when an exception is thrown.")
+    public void testScheduledAsynchCompletedExceptionally() {
+        runTest(baseURL, testname);
+    }
 
+    @Assertion(id = "GIT:439", strategy = "Ensure overlapping scheduled asynchronous methods are skipped.")
+    public void testScheduledAsynchOverlapSkipping() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods ignore the max-async configuration."
+            + " Ensure scheduled asynchronous methods honor cleared context configuration")
+    public void testScheduledAsynchIgnoresMaxAsync() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods choose closest execution time when multiple schedules are provided."
+            + " Ensure scheduled asynchronous methods honor propogated context configuration")
+    public void testScheduledAsynchWithMultipleSchedules() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are not executed when an invalid JNDI name is provided.")
+    public void testScheduledAsynchWithInvalidJNDIName() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods with void return type stop execution via completable future or exception.")
+    public void testScheduledAsynchVoidReturn() {
+        runTest(baseURL, testname);
+    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionFullTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionFullTests.java
@@ -32,7 +32,6 @@ import ee.jakarta.tck.concurrent.framework.URLBuilder;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Assertion;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Challenge;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common.PACKAGE;
-import ee.jakarta.tck.concurrent.framework.junit.anno.Debug;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Full;
 import ee.jakarta.tck.concurrent.framework.junit.anno.TestName;
 import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextServiceDefinitionBean;
@@ -41,7 +40,6 @@ import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextSer
 import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
 
 @Full
-@Debug //TODO remove after testing
 @RunAsClient // Requires client testing due to multiple servlets and annotation configuration
 public class ManagedExecutorDefinitionFullTests extends TestClient {
 

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionServlet.java
@@ -16,19 +16,28 @@
 package ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import javax.naming.InitialContext;
@@ -37,7 +46,9 @@ import javax.naming.NamingException;
 import ee.jakarta.tck.concurrent.common.context.IntContext;
 import ee.jakarta.tck.concurrent.common.context.StringContext;
 import ee.jakarta.tck.concurrent.framework.TestServlet;
+import ee.jakarta.tck.concurrent.framework.junit.extensions.Wait;
 import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextServiceDefinitionServlet;
+import ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef.AppBean.RETURN;
 import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
@@ -503,6 +514,241 @@ public class ManagedExecutorDefinitionServlet extends TestServlet {
                             + "per java:comp/concurrent/ExecutorC configuration.");
         } finally {
             tx.rollback();
+        }
+    }
+    
+    public void testScheduledAsynchCompletedFuture() throws Throwable {
+        AtomicInteger counter = new AtomicInteger();
+        
+        // Method returns an incomplete future - stopping schedule because non-null value is returned
+        try {
+            CompletableFuture<Integer> future = appBean.scheduledEvery5seconds(1, RETURN.INCOMPLETE, counter);
+            assertThrows(TimeoutException.class, () -> { // Slow assertion
+                future.get(10, TimeUnit.SECONDS);
+            });
+            
+            assertFalse(future.isCancelled());
+            assertFalse(future.isCompletedExceptionally());
+            assertFalse(future.isDone());
+            assertEquals(1, counter.get(), "Schedule should have executed exactly once.");
+            
+            future.cancel(false); // Cleanup resources
+        } finally {
+            counter.set(0);
+        }
+
+        
+        // Caller completes future before scheduled asynch is completed - stopping schedule because future was cancelled
+        try {
+            CompletableFuture<Integer> future = appBean.scheduledEvery5seconds(1, RETURN.NULL, counter);
+            
+            assertFalse(future.isCancelled());
+            assertFalse(future.isCompletedExceptionally());
+            assertFalse(future.isDone());
+            
+            int countBeforeCancel = counter.get();
+            future.cancel(false);
+            assertThrows(CancellationException.class, () -> {
+                future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS);
+            });
+            int countAfterCancel = counter.get();
+            
+            assertTrue((countAfterCancel - countBeforeCancel) <= 1, "Schedule should not have executed more than once after cancel was called.");
+        } finally {
+            counter.set(0);
+        }
+    }
+    
+    
+    public void testScheduledAsynchCompletedResult() throws Throwable {
+        AtomicInteger counter = new AtomicInteger();
+        
+        // Method returns an expected result - stopping schedule because non-null value is returned
+        try {
+            int expected = 3;
+            CompletableFuture<Integer> future = appBean.scheduledEvery5seconds(expected, RETURN.COMPLETE_RESULT, counter);
+            
+            int result = future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS); // Slow assertion
+            
+            assertFalse(future.isCancelled());
+            assertFalse(future.isCompletedExceptionally());
+            assertTrue(future.isDone());
+            assertEquals(expected, result);
+        } finally {
+            counter.set(0);
+        }
+
+    }
+    
+    /**
+     * Ensure completion of scheduled asynch after completing exceptionally
+     */
+    public void testScheduledAsynchCompletedExceptionally() {
+        AtomicInteger counter = new AtomicInteger();
+        
+        // Method invokes completeExceptionally - stopping schedule because non-null value is returned
+        try {
+            String expected = "testScheduledAsynchCompletedExceptionally-1";
+            CompletableFuture<Integer> future = appBean.scheduledEvery5seconds(1, RETURN.COMPLETE_EXCEPTIONALLY.withMessage(expected), counter);
+            
+            ExecutionException cause = assertThrows(ExecutionException.class, () -> {
+                future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS);
+            });
+            
+            assertFalse(future.isCancelled());
+            assertTrue(future.isCompletedExceptionally());
+            assertTrue(future.isDone());
+            assertTrue(cause.getMessage().contains(expected));
+            assertEquals(1, counter.get(), "Schedule should have executed exactly once.");
+            
+        } finally {
+            counter.set(0);
+        }
+
+        // Method throws exception, platform invokes completeExceptionally - stopping schedule because future is completed
+        try {
+            String expected = "testScheduledAsynchCompletedExceptionally-2";
+            CompletableFuture<Integer> future = appBean.scheduledEvery5seconds(1, RETURN.THROW_EXCEPTION.withMessage(expected), counter);
+            
+            ExecutionException cause = assertThrows(ExecutionException.class, () -> {
+                future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS);
+            });
+            
+            assertFalse(future.isCancelled());
+            assertTrue(future.isCompletedExceptionally());
+            assertTrue(future.isDone());
+            assertTrue(cause.getMessage().contains(expected));
+            assertEquals(1, counter.get());
+        } finally {
+            counter.set(0);
+        }
+    }
+    
+    
+    public void testScheduledAsynchOverlapSkipping() throws Throwable {
+        AtomicInteger counter = new AtomicInteger();
+        
+        try {
+            int expected = 3;
+            CompletableFuture<Integer> future = appBean.scheduledEvery3SecondsTakes5Seconds(expected, counter);
+            
+            // If scheduled async tasks are not skipped while overlapping this will fail
+            assertThrows(TimeoutException.class, () -> { // Slow assertion
+                future.get(expected * 3, TimeUnit.SECONDS);
+            });
+            
+            int result = future.get(expected * 5, TimeUnit.SECONDS);
+            assertEquals(expected, result);
+            
+        } finally {
+            counter.set(0);
+        }
+    }
+    
+    public void testScheduledAsynchIgnoresMaxAsync() throws Throwable {
+        ManagedExecutorService executor = InitialContext.doLookup("java:module/concurrent/ExecutorB");
+
+        BlockingQueue<Integer> results = new LinkedBlockingQueue<Integer>();
+        CountDownLatch blocker = new CountDownLatch(1);
+
+        Runnable task = () -> {
+            results.add(IntContext.get());
+            try {
+                blocker.await(MAX_WAIT_SECONDS * 5, TimeUnit.SECONDS);
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        };
+        
+        AtomicInteger counter = new AtomicInteger();
+
+        try {
+            IntContext.set(22); //Context should be cleared
+
+            executor.runAsync(task);
+            executor.runAsync(task);
+            CompletableFuture<Integer> future = appBean.scheduledEvery3Seconds(1, counter);
+            
+
+            assertEquals(Integer.valueOf(0), results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
+                    "ManagedExecutorService with maxAsync=1 must be able to run an async task.");
+            
+            assertEquals(null, results.poll(1, TimeUnit.SECONDS),
+                    "ManagedExecutorService with maxAsync=1 must not run 2 async tasks concurrently.");
+
+            assertEquals(Integer.valueOf(0), future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
+                    "ManagedExecutorService with maxAsync=1 must be able to run scheduled async methods concurrently.");
+        } finally {
+            IntContext.set(0);
+            counter.set(0);
+            blocker.countDown();
+        }
+    }
+    
+    public void testScheduledAsynchWithMultipleSchedules() throws Throwable {
+        AtomicInteger counter = new AtomicInteger();
+        
+        try {
+            String expected = "testScheduledAsynchWithMultipleSchedules";
+            StringContext.set(expected);
+            
+            CompletableFuture<String> future = appBean.scheduledEvery3SecondsAnd1Minute(5, counter);
+            
+            String result = future.get(1, TimeUnit.MINUTES);
+            assertEquals(expected, result);
+            
+        } finally {
+            StringContext.set(null);
+            counter.set(0);
+        }
+    }
+    
+    public void testScheduledAsynchWithInvalidJNDIName() {
+        assertThrows(RejectedExecutionException.class, () -> {
+            appBean.scheduledInvalidExecutor();
+        });
+    }
+    
+    public void testScheduledAsynchVoidReturn() {
+        AtomicInteger counter = new AtomicInteger();
+        
+        // Test future.complete(null);
+        try {
+            int expected = 3;
+            appBean.scheduledEvery3SecondsVoidReturn(expected, RETURN.COMPLETE_RESULT, counter);
+            assertTimeoutPreemptively(Duration.ofSeconds(MAX_WAIT_SECONDS), () -> {
+                for (; expected != counter.get(); Wait.sleep(Duration.ofSeconds(3))) {
+                    //empty
+                }
+            });
+        } finally {
+            counter.set(0);
+        }
+        
+        // Test future.completeExceptionally();
+        try {
+            int expected = 3;
+            appBean.scheduledEvery3SecondsVoidReturn(expected, RETURN.COMPLETE_EXCEPTIONALLY, counter);
+            assertTimeoutPreemptively(Duration.ofSeconds(MAX_WAIT_SECONDS), () -> {
+                for (; expected != counter.get(); Wait.sleep(Duration.ofSeconds(3))) {
+                    //empty
+                }
+            });
+        } finally {
+            counter.set(0);
+        }
+        
+        // Test method throws exception
+        try {
+            int expected = 3;
+            appBean.scheduledEvery3SecondsVoidReturn(expected, RETURN.THROW_EXCEPTION, counter);
+            assertTimeoutPreemptively(Duration.ofSeconds(MAX_WAIT_SECONDS), () -> {
+                for (; expected != counter.get(); Wait.sleep(Duration.ofSeconds(3))) {
+                    //empty
+                }
+            });
+        } finally {
+            counter.set(0);
         }
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebTests.java
@@ -30,7 +30,6 @@ import ee.jakarta.tck.concurrent.framework.URLBuilder;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Assertion;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Challenge;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common;
-import ee.jakarta.tck.concurrent.framework.junit.anno.Debug;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common.PACKAGE;
 import ee.jakarta.tck.concurrent.framework.junit.anno.TestName;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Web;
@@ -40,7 +39,6 @@ import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextSer
 import jakarta.enterprise.concurrent.spi.ThreadContextProvider;;
 
 @Web
-@Debug //TODO remove after testing
 @RunAsClient // Requires client testing due to multiple servlets and annotation configuration
 @Common({ PACKAGE.CONTEXT, PACKAGE.CONTEXT_PROVIDERS })
 public class ManagedExecutorDefinitionWebTests extends TestClient {

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionWebTests.java
@@ -30,6 +30,7 @@ import ee.jakarta.tck.concurrent.framework.URLBuilder;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Assertion;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Challenge;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common;
+import ee.jakarta.tck.concurrent.framework.junit.anno.Debug;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common.PACKAGE;
 import ee.jakarta.tck.concurrent.framework.junit.anno.TestName;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Web;
@@ -39,6 +40,7 @@ import ee.jakarta.tck.concurrent.spec.ContextService.contextPropagate.ContextSer
 import jakarta.enterprise.concurrent.spi.ThreadContextProvider;;
 
 @Web
+@Debug //TODO remove after testing
 @RunAsClient // Requires client testing due to multiple servlets and annotation configuration
 @Common({ PACKAGE.CONTEXT, PACKAGE.CONTEXT_PROVIDERS })
 public class ManagedExecutorDefinitionWebTests extends TestClient {
@@ -142,5 +144,46 @@ public class ManagedExecutorDefinitionWebTests extends TestClient {
     public void testManagedExecutorDefinitionDefaults() {
         runTest(baseURL, testname);
     }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when future is completed.")
+    public void testScheduledAsynchCompletedFuture() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when a non-null result is returned.")
+    public void testScheduledAsynchCompletedResult() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when an exception is thrown.")
+    public void testScheduledAsynchCompletedExceptionally() {
+        runTest(baseURL, testname);
+    }
 
+    @Assertion(id = "GIT:439", strategy = "Ensure overlapping scheduled asynchronous methods are skipped.")
+    public void testScheduledAsynchOverlapSkipping() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods ignore the max-async configuration."
+            + " Ensure scheduled asynchronous methods honor cleared context configuration")
+    public void testScheduledAsynchIgnoresMaxAsync() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods choose closest execution time when multiple schedules are provided."
+            + " Ensure scheduled asynchronous methods honor propogated context configuration")
+    public void testScheduledAsynchWithMultipleSchedules() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are not executed when an invalid JNDI name is provided.")
+    public void testScheduledAsynchWithInvalidJNDIName() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods with void return type stop execution via completable future or exception.")
+    public void testScheduledAsynchVoidReturn() {
+        runTest(baseURL, testname);
+    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionFullTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionFullTests.java
@@ -176,4 +176,47 @@ public class ManagedScheduledExecutorDefinitionFullTests extends TestClient {
     public void testScheduleWithZonedTrigger() {
         runTest(baseURL, testname);
     }
+
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when future is completed.")
+    public void testScheduledAsynchCompletedFuture() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when a non-null result is returned.")
+    public void testScheduledAsynchCompletedResult() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when an exception is thrown.")
+    public void testScheduledAsynchCompletedExceptionally() {
+        runTest(baseURL, testname);
+    }
+
+    @Assertion(id = "GIT:439", strategy = "Ensure overlapping scheduled asynchronous methods are skipped.")
+    public void testScheduledAsynchOverlapSkipping() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods ignore the max-async configuration."
+            + " Ensure scheduled asynchronous methods honor cleared context configuration")
+    public void testScheduledAsynchIgnoresMaxAsync() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods choose closest execution time when multiple schedules are provided."
+            + " Ensure scheduled asynchronous methods honor propogated context configuration")
+    public void testScheduledAsynchWithMultipleSchedules() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are not executed when an invalid JNDI name is provided.")
+    public void testScheduledAsynchWithInvalidJNDIName() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods with void return type stop execution via completable future or exception.")
+    public void testScheduledAsynchVoidReturn() {
+        runTest(baseURL, testname);
+    }
+
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionWebTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionWebTests.java
@@ -165,4 +165,47 @@ public class ManagedScheduledExecutorDefinitionWebTests extends TestClient {
      public void testScheduleWithZonedTrigger() {
         runTest(baseURL, testname);
     }
+
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when future is completed.")
+    public void testScheduledAsynchCompletedFuture() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when a non-null result is returned.")
+    public void testScheduledAsynchCompletedResult() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are completed when an exception is thrown.")
+    public void testScheduledAsynchCompletedExceptionally() {
+        runTest(baseURL, testname);
+    }
+
+    @Assertion(id = "GIT:439", strategy = "Ensure overlapping scheduled asynchronous methods are skipped.")
+    public void testScheduledAsynchOverlapSkipping() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods ignore the max-async configuration."
+            + " Ensure scheduled asynchronous methods honor cleared context configuration")
+    public void testScheduledAsynchIgnoresMaxAsync() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods choose closest execution time when multiple schedules are provided."
+            + " Ensure scheduled asynchronous methods honor propogated context configuration")
+    public void testScheduledAsynchWithMultipleSchedules() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods are not executed when an invalid JNDI name is provided.")
+    public void testScheduledAsynchWithInvalidJNDIName() {
+        runTest(baseURL, testname);
+    }
+    
+    @Assertion(id = "GIT:439", strategy = "Ensure scheduled asynchronous methods with void return type stop execution via completable future or exception.")
+    public void testScheduledAsynchVoidReturn() {
+        runTest(baseURL, testname);
+    }
+
 }

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ReqBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ReqBean.java
@@ -15,12 +15,15 @@
  */
 package ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -29,12 +32,18 @@ import ee.jakarta.tck.concurrent.common.context.IntContext;
 import ee.jakarta.tck.concurrent.common.context.StringContext;
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.concurrent.Schedule;
 import jakarta.enterprise.context.RequestScoped;
 
 @RequestScoped
 public class ReqBean {
+
+    private static final Logger log = Logger.getLogger(ReqBean.class.getCanonicalName());
+
     private static final long MAX_WAIT_SECONDS = TimeUnit.MINUTES.toSeconds(2);
 
+    // Asynchronous Tests
+    
     @Asynchronous(executor = "java:app/concurrent/ScheduledExecutorA")
     public CompletableFuture<String> awaitAndGetThirdPartyContext(final Semaphore invocationsStarted,
             final CountDownLatch blocker) {
@@ -60,5 +69,189 @@ public class ReqBean {
 
     public CompletableFuture<String> notAsynchronous() {
         return CompletableFuture.completedFuture(Thread.currentThread().getName());
+    }
+    
+    // Scheduled Asynchronous Tests
+    public static enum RETURN {
+            NULL, // Never completes
+            COMPLETE_EXCEPTIONALLY, // Completes with exception
+            COMPLETE_RESULT, // Completes with result
+            INCOMPLETE, // Returns future that is not complete
+            THROW_EXCEPTION; // Method throws exception
+            
+            private String message = "";
+            
+            public RETURN withMessage(final String m) {
+                this.message = m;
+                return this;
+            }
+            
+            public String getMessage() {
+                return message;
+            }
+    }
+    
+    /**
+     * A scheduled async method that runs every 5 seconds
+     *
+     * @param runs - how many times to run before returning
+     * @param type - how this method should return (successfully / incomplete / exceptionally)
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return A result or exception
+     */
+    @Asynchronous(executor = "java:comp/DefaultManagedScheduledExecutorService", runAt = @Schedule(cron = "*/5 * * * * *"))
+    public CompletableFuture<Integer> scheduledEvery5seconds(final int runs, final RETURN type, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery5seconds method " + count + "/" + runs + " (Returning: " + type.toString() + ")");
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Integer> future = Asynchronous.Result.getFuture();
+        
+        switch (type) {
+        case NULL: //Never stop executions
+            return null;
+        case COMPLETE_EXCEPTIONALLY:
+            future.completeExceptionally(new Exception(type.getMessage()));
+            break;
+        case COMPLETE_RESULT:
+            future.complete(count);
+            break;
+        case INCOMPLETE:
+            break; //never complete future
+        case THROW_EXCEPTION:
+            throw new RuntimeException(type.getMessage());
+        default:
+            break;
+        }
+        
+        return future;
+    }
+    
+    @Asynchronous(executor = "java:comp/DefaultManagedScheduledExecutorService", runAt = @Schedule(cron = "*/3 * * * * *"))
+    public void scheduledEvery3SecondsVoidReturn(final int runs, final RETURN type, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3SecondsVoidReturn method " + count + "/" + runs + " (Returning: " + type.toString() + ")");
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Void> future = Asynchronous.Result.getFuture();
+        
+        switch (type) {
+        case COMPLETE_EXCEPTIONALLY:
+            future.completeExceptionally(new Exception(type.getMessage()));
+            break;
+        case COMPLETE_RESULT:
+            future.complete(null);
+            break;
+        case THROW_EXCEPTION:
+            throw new RuntimeException(type.getMessage());
+        default:
+            break;
+        }
+    }
+    
+    /**
+     * A scheduled async method that runs every 3 seconds, but takes 5 seconds to complete
+     *
+     * @param runs - how many times to run before returning
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return The number of runs completed
+     */
+    @Asynchronous(executor = "java:comp/DefaultManagedScheduledExecutorService", runAt = @Schedule(cron = "*/3 * * * * *"))
+    public CompletableFuture<Integer> scheduledEvery3SecondsTakes5Seconds(final int runs, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3SecondsTakes5Seconds method " + count + "/" + runs);
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            
+            try {
+                Thread.sleep(Duration.ofSeconds(5).toMillis());
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Thread was interrupted while waiting", e);
+            }
+            
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Integer> future = Asynchronous.Result.getFuture();
+        future.complete(count);
+        
+        return future;
+    }
+    
+    /**
+     * A scheduled async method that runs every 3 seconds
+     * Uses executor = "java:module/concurrent/ScheduledExecutorB" with max-async = 4
+     *
+     * @param runs - how many times to run before returning
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return completed future of IntContext
+     */
+    @Asynchronous(executor = "java:module/concurrent/ScheduledExecutorB", runAt = @Schedule(cron = "*/3 * * * * *"))
+    public CompletableFuture<Integer> scheduledEvery3Seconds(final int runs, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3Seconds method " + count + "/" + runs);
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<Integer> future = Asynchronous.Result.getFuture();
+        future.complete(IntContext.get());
+        
+        return future;
+    }
+    
+    /**
+     * A scheduled async method that runs every 3 seconds and every minute
+     * Uses executor = "java:module/concurrent/ScheduledExecutorB" with max-async = 4
+     *
+     * @param runs - how many times to run before returning
+     * @param counter - The counter provided from the caller to compare against
+     *
+     * @return completed future of StringContext
+     */
+    @Asynchronous(executor = "java:module/concurrent/ScheduledExecutorB", runAt = {
+            @Schedule(cron = "*/3 * * * * *"),
+            @Schedule(cron = "0 * * * * *")
+    })
+    public CompletableFuture<String> scheduledEvery3SecondsAnd1Minute(final int runs, final AtomicInteger counter) {
+        int count = counter.incrementAndGet();
+        
+        log.info("Executing scheduledEvery3SecondsAnd1Minute method " + count + "/" + runs);
+        log.info("  Thread: " + Thread.currentThread().toString());
+        
+        if (runs != count) {
+            return null; // Continue onto next scheduled execution
+        }
+        
+        CompletableFuture<String> future = Asynchronous.Result.getFuture();
+        future.complete(StringContext.get());
+        
+        return future;
+    }
+    
+    /**
+     * A scheduled async method that should not run due to invalid configuration
+     */
+    @Asynchronous(executor = "java:app/concurrent/INVALID", runAt = @Schedule(cron = "*/3 * * * * *"))
+    public CompletableFuture<String> scheduledInvalidExecutor() {
+        throw new UnsupportedOperationException("Should not be able to execute with invalid executor");
     }
 }


### PR DESCRIPTION
Fixes #439 

DRAFT:
- [x] https://github.com/jakartaee/concurrency/pull/444
- [x] Need to test scheduled asynchronous methods backed by a ManagedScheduledExecutor service.