### PR TITLE
Fix Tests Depending on Static Counter by Resetting Before Tests

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedThreadFactory/ManagedThreadFactoryTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/ManagedThreadFactory/ManagedThreadFactoryTests.java
@@ -60,6 +60,7 @@ public class ManagedThreadFactoryTests extends TestClient {
     @Assertion(id = "SPEC:83 SPEC:83.1 SPEC:83.2 SPEC:83.3 SPEC:103 SPEC:96.5 SPEC:96.6 SPEC:105 SPEC:96 SPEC:93 SPEC:96.3",
             strategy = "Interrupt thread and ensure the thread did not run.")
     public void interruptThreadApiTest() {
+        StaticCounter.reset();
         CounterRunnableTask task = new CounterRunnableTask(TestConstants.pollInterval);
         Thread thread = threadFactory.newThread(task);
         thread.start();

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/inheritedapi/InheritedAPITests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/inheritedapi/InheritedAPITests.java
@@ -44,6 +44,7 @@ import ee.jakarta.tck.concurrent.framework.junit.extensions.Assertions;
 import ee.jakarta.tck.concurrent.framework.junit.extensions.Wait;
 import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
+import org.junit.jupiter.api.BeforeEach;
 
 @Web
 @Common({ PACKAGE.TASKS, PACKAGE.FIXED_COUNTER })
@@ -56,6 +57,11 @@ public class InheritedAPITests {
 
     @Resource(lookup = TestConstants.defaultManagedExecutorService)
     private ManagedExecutorService executor;
+
+    @BeforeEach
+    public void reset() {
+        StaticCounter.reset();
+    }
 
     @Assertion(id = "SPEC:10.2; SPEC:13; SPEC:13.1; SPEC:13.2",
             strategy = "Test basic function for ManagedExecutorService: execute")


### PR DESCRIPTION
Some tests are failing, because the static counter is set by previous tests. Simple reset of the counter before tests fixes it.