### PR TITLE
Remove Dependency from Framework to Tests

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/junit/extensions/Wait.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/junit/extensions/Wait.java
@@ -21,11 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import java.time.Duration;
 import java.util.concurrent.Future;
 
-import ee.jakarta.tck.concurrent.common.counter.CounterInterface;
 import ee.jakarta.tck.concurrent.common.managed.task.listener.ListenerEvent;
 import ee.jakarta.tck.concurrent.common.managed.task.listener.ManagedTaskListenerImpl;
 import ee.jakarta.tck.concurrent.common.transaction.CancelledTransactedTask;
 import ee.jakarta.tck.concurrent.framework.TestConstants;
+import java.util.function.IntSupplier;
 
 /**
  * Utility class for waiting for results.
@@ -159,9 +159,9 @@ public final class Wait {
      * @param counter
      * @param expected
      */
-    public static void waitForCounter(final CounterInterface counter, final int expected) {
+    public static void waitForCounter(final IntSupplier counter, final int expected) {
         assertTimeoutPreemptively(TestConstants.waitTimeout, () -> {
-            for (; expected != counter.getCount(); Wait.sleep(TestConstants.pollInterval)) {
+            for (; expected != counter.getAsInt(); Wait.sleep(TestConstants.pollInterval)) {
                 //empty
             }
         });

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/inheritedapi/TestEjb.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/inheritedapi/TestEjb.java
@@ -69,7 +69,7 @@ public class TestEjb implements TestEjbInterface {
         try {
             EJBJNDIProvider nameProvider = ServiceLoader.load(EJBJNDIProvider.class).findFirst().orElseThrow();
             scheduledExecutor.execute(new CounterRunnableTask(nameProvider.getEJBJNDIName()));
-            Wait.waitForCounter(counter, 1);
+            Wait.waitForCounter(() -> counter.getCount(), 1);
         } finally {
             counter.reset();
         }


### PR DESCRIPTION
The framework package is delivered as a jar in /lib/jakarta-concurrent-framework.jar, although it depends on test class CounterInterface, depolyed in /inheritedapi.jar.
This change removes this dependency by calling the counter via `Supplier`.

