### PR TITLE
Clarify test counts in TCK documentation

### DIFF
--- a/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
@@ -343,7 +343,7 @@ $ mvn clean test
 
 === Expected Output
 
-Here is example output when the starter runner runs successfully:
+Here is example output when the starter runner runs successfully in full mode:
 
 include::generated/expected-output.adoc[]
 


### PR DESCRIPTION
As discussed here: https://github.com/jakartaee/specifications/pull/733

The test counts in the TCK documentation were misleading: 
- Documented - `[WARNING] Tests run: 268, Failures: 0, Errors: 0, Skipped: 27`
- Reality           - `[WARNING] Tests run: 295, Failures: 0, Errors: 0, Skipped: 27`

I made the false assumption that the Tests Run did not include skipped tests, when in reality the skipped tests are double counted. 