### PR TITLE
Update certifcation documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/certification.yml
+++ b/.github/ISSUE_TEMPLATE/certification.yml
@@ -44,8 +44,8 @@ body:
       label: Technology Compatibility Kit (TCK) Validation
       description: |
         SHA-256 Checksum
-        This is the checksum of the TCK jar, not the TCK distribution zip
-        Example: `shasum -a 256 jakarta.enterprise.concurrent-tck-3.1.0.jar`
+        This is the checksum of the TCK Distribution zip, not the checksum for the TCK jar artifact.
+        Example: `shasum -a 256 jakarta.enterprise.concurrent-tck-dist-3.1.0-dist.zip`
   - type: textarea
     id: tckResults
     validations:

--- a/.github/ISSUE_TEMPLATE/certification.yml
+++ b/.github/ISSUE_TEMPLATE/certification.yml
@@ -42,7 +42,10 @@ body:
       required: true
     attributes: 
       label: Technology Compatibility Kit (TCK) Validation
-      description: TCK SHA-256 fingerprint
+      description: |
+        SHA-256 Checksum
+        This is the checksum of the TCK jar, not the TCK distribution zip
+        Example: `shasum -a 256 jakarta.enterprise.concurrent-tck-3.1.0.jar`
   - type: textarea
     id: tckResults
     validations:

--- a/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
@@ -9,11 +9,12 @@
 :APIShortNameLC: concurrency
 :APILongName: Jakarta Concurrency
 :APIVersion: 3.1.0
-:APISpecSite: https://jakarta.ee/specifications/concurrency/3.0/
+:APISpecSite: https://jakarta.ee/specifications/concurrency/3.1/
 :APIEclipseSite: https://projects.eclipse.org/projects/ee4j.cu
 :APIGitSite: https://github.com/jakartaee/concurrency
 :TCKTestPlatform: Junit5
 :SigPluginGAV: org.netbeans.tools:sigtest-maven-plugin:1.6
+:last-update-label!:
 
 == Preface
 


### PR DESCRIPTION
SHA checksum for individual TCKs should be run on the TCK jar and not the TCK distribution zip.