### PR TITLE
add ApplicationScoped to TCK servlet that defines resources that have qualifiers

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationServlet.java
@@ -51,12 +51,14 @@ import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.transaction.Status;
 import jakarta.transaction.UserTransaction;
 
+@ApplicationScoped
 @ContextServiceDefinition(
         name = "java:app/concurrent/ContextE",
         qualifiers = {CustomQualifier1.class},


### PR DESCRIPTION
fixes #489

This is the servlet that I'm aware of that defines concurrency resources that specify qualifiers.  For those of you who were seeing the failures, please confirm and let me know if there were other places as well that I didn't see.