### PR TITLE
AnnotationFullTests adds resource definitions with qualifiers on a CDI bean

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/anno/AnnotationServlet.java
@@ -51,7 +51,7 @@ import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
-import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -82,7 +82,7 @@ import jakarta.transaction.UserTransaction;
         priority = 6
         )
 @WebServlet("/AnnotationServlet")
-@ApplicationScoped
+@Dependent
 public class AnnotationServlet extends TestServlet {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
The servlet `AnnotationServlet` turned into an `Dependent` CDI bean so that it's scanned by a CDI extension, which can then read the definitions from the annotations.

I decided to use `@Dependent` scope because Servlet spec version 3.0 explicitly forbids other CDI scopes for servlets. Some servers still abide this even though it seems this restriction was removed in newer Servlet spec versions. Concurrency TCK should not contain any assertions for other specs, so I use widely accepted `@Dependent`.

Fixes #489
