### PR TITLE
DeploymentDescriptorFull/WebTests Adds Resource Definitions with Qualifiers on a CDI Bean

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorServlet.java
@@ -43,6 +43,7 @@ import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -50,6 +51,7 @@ import jakarta.transaction.Status;
 import jakarta.transaction.UserTransaction;
 
 @WebServlet("/DeploymentDescriptorServlet")
+@Dependent
 public class DeploymentDescriptorServlet extends TestServlet {
     private static final long serialVersionUID = 1L;
     private static final long MAX_WAIT_SECONDS = TimeUnit.MINUTES.toSeconds(2);


### PR DESCRIPTION
Adding the same annotation as in https://github.com/jakartaee/concurrency/pull/491

DeploymentDescriptorFull/WebTests are basically the same tests as AnnotationFull/WebTests, just requiring loading the definitions from xml files.