### PR TITLE
Removing Tests of Context Switch from Asynchronous Tests

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionServlet.java
@@ -17,6 +17,7 @@ package ee.jakarta.tck.concurrent.spec.ManagedExecutorService.resourcedef;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -666,13 +667,15 @@ public class ManagedExecutorDefinitionServlet extends TestServlet {
             executor.runAsync(task);
             executor.runAsync(task);
             CompletableFuture<Integer> future = appBean.scheduledEvery3Seconds(1, counter);
-            
 
             assertEquals(Integer.valueOf(0), results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
                     "ManagedExecutorService with maxAsync=1 must be able to run an async task.");
             
             assertEquals(null, results.poll(1, TimeUnit.SECONDS),
                     "ManagedExecutorService with maxAsync=1 must not run 2 async tasks concurrently.");
+
+            assertNotNull(future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
+                    "ManagedExecutorService with maxAsync=1 must be able to run scheduled async methods concurrently.");
         } finally {
             IntContext.set(0);
             counter.set(0);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedExecutorService/resourcedef/ManagedExecutorDefinitionServlet.java
@@ -663,8 +663,6 @@ public class ManagedExecutorDefinitionServlet extends TestServlet {
         AtomicInteger counter = new AtomicInteger();
 
         try {
-            IntContext.set(22); //Context should be cleared
-
             executor.runAsync(task);
             executor.runAsync(task);
             CompletableFuture<Integer> future = appBean.scheduledEvery3Seconds(1, counter);
@@ -675,9 +673,6 @@ public class ManagedExecutorDefinitionServlet extends TestServlet {
             
             assertEquals(null, results.poll(1, TimeUnit.SECONDS),
                     "ManagedExecutorService with maxAsync=1 must not run 2 async tasks concurrently.");
-
-            assertEquals(Integer.valueOf(0), future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
-                    "ManagedExecutorService with maxAsync=1 must be able to run scheduled async methods concurrently.");
         } finally {
             IntContext.set(0);
             counter.set(0);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
@@ -763,15 +763,11 @@ public class ManagedScheduledExecutorDefinitionServlet extends TestServlet {
         AtomicInteger counter = new AtomicInteger();
 
         try {
-            IntContext.set(22); //Context should be cleared
-
             executor.runAsync(task);
             executor.runAsync(task);
             executor.runAsync(task);
             executor.runAsync(task);
             executor.runAsync(task);
-            CompletableFuture<Integer> future = reqBean.scheduledEvery3Seconds(1, counter);
-            
 
             assertEquals(Integer.valueOf(0), results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
                     "ManagedScheduledExecutorService with maxAsync=4 must be able to run one async task.");
@@ -787,9 +783,6 @@ public class ManagedScheduledExecutorDefinitionServlet extends TestServlet {
             
             assertEquals(null, results.poll(1, TimeUnit.SECONDS),
                     "ManagedScheduledExecutorService with maxAsync=4 must not run 5 async tasks concurrently.");
-
-            assertEquals(Integer.valueOf(0), future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
-                    "ManagedScheduledExecutorService with maxAsync=4 must be able to run scheduled async methods concurrently.");
         } finally {
             IntContext.set(0);
             counter.set(0);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
@@ -769,6 +769,8 @@ public class ManagedScheduledExecutorDefinitionServlet extends TestServlet {
             executor.runAsync(task);
             executor.runAsync(task);
 
+            CompletableFuture<Integer> future = reqBean.scheduledEvery3Seconds(1, counter);
+
             assertEquals(Integer.valueOf(0), results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
                     "ManagedScheduledExecutorService with maxAsync=4 must be able to run one async task.");
             
@@ -783,6 +785,9 @@ public class ManagedScheduledExecutorDefinitionServlet extends TestServlet {
             
             assertEquals(null, results.poll(1, TimeUnit.SECONDS),
                     "ManagedScheduledExecutorService with maxAsync=4 must not run 5 async tasks concurrently.");
+
+            assertNotNull(future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
+                    "ManagedScheduledExecutorService with maxAsync=4 must be able to run scheduled async methods concurrently.");
         } finally {
             IntContext.set(0);
             counter.set(0);


### PR DESCRIPTION
I removed tests of context switch, which tested, that the context capture happened during jndi lookup. The test later setup number 22 and the test checks, if asynchronous method (running via scheduler) returns 0.

The code:
```
ManagedExecutorDefinitionFullTests.testScheduledAsynchIgnoresMaxAsync() {
...
            IntContext.set(22); //Context should be cleared
            CompletableFuture<Integer> future = reqBean.scheduledEvery3Seconds(1, counter);
...
            assertEquals(Integer.valueOf(0), future.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS),
                    "ManagedScheduledExecutorService with maxAsync=4 must be able to run scheduled async methods concurrently.");
```
`reqBean.scheduledEvery3Seconds` runs only once and returns `IntContext`: `future.complete(IntContext.get())`

1. There is no explicit setup of the IntContext value to test.
2. This test checks just the context switch, not asynch methods running concurrently as it says in the message. Although it is called schedule, it runs only once.

The discussion, if the context capture should happen on JNDI lookup or when the thread is created, is still open: https://github.com/jakartaee/concurrency/issues/253