### PR TITLE
Use jakarta.tck:sigtest-maven-plugin in 3.0 service stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: 
+        - 'main'
+        - 'RELEASE-*'
+  pull_request:
+    branches:
+        - 'main'
+        - 'RELEASE-*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    # TODO update once 25-ea is available
+    strategy:
+      matrix:
+        java-version: [ '11', '17', '21' ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Set up JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B -Pstaging package --file pom.xml

--- a/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/concurrency-tck-reference-guide.adoc
@@ -8,13 +8,13 @@
 :APIShortName: Concurrency
 :APIShortNameLC: concurrency
 :APILongName: Jakarta Concurrency
-:APIVersion: 3.0.0
+:APIVersion: 3.0
 :APISpecSite: https://jakarta.ee/specifications/concurrency/3.0/
 :APIEclipseSite: https://projects.eclipse.org/projects/ee4j.cu
 :APIGitSite: https://github.com/jakartaee/concurrency
 :TCKTestPlatform: TestNG
 :RuntimeTestCount: 164
-:SigPluginGAV: org.netbeans.tools:sigtest-maven-plugin:1.6
+:SigPluginGAV: jakarta.tck:sigtest-maven-plugin:2.3
 
 == Preface
 
@@ -272,7 +272,7 @@ The TCK uses external libraries that also need to be available on the Applicatio
 
 - org.apache.derby:derby - For database testing
 - org.testng:testng - For test assertions
-- org.netbeans.tools:sigtest-maven-plugin - For signature testing
+- jakarta.tck:sigtest-maven-plugin - For signature testing
 
 See <<Test Server Dependencies>>
 

--- a/tck-dist/src/main/starter/pom.xml
+++ b/tck-dist/src/main/starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,7 +37,7 @@
         <jakarta.concurrent.version>3.0.0</jakarta.concurrent.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <testng.version>6.14.3</testng.version>
-        <sigtest.version>1.6</sigtest.version>
+        <sigtest.version>2.3</sigtest.version>
         <derby.version>10.15.2.0</derby.version>
         <maven.dep.plugin.version>3.3.0</maven.dep.plugin.version>
         <maven.comp.plugin.version>3.10.1</maven.comp.plugin.version>
@@ -114,7 +114,7 @@
         </dependency>
         <!-- Signature Test Plugin -->
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
             <version>${sigtest.version}</version>
         </dependency>
@@ -144,7 +144,7 @@
                             <version>${derby.version}</version>
                         </artifactItem>
                         <artifactItem>
-                            <groupId>org.netbeans.tools</groupId>
+                            <groupId>jakarta.tck</groupId>
                             <artifactId>sigtest-maven-plugin</artifactId>
                             <version>${sigtest.version}</version>
                         </artifactItem>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,15 +44,14 @@
     </licenses>
 
     <properties>
-        <jakarta.concurrent.api.version>3.0.1</jakarta.concurrent.api.version>
-        <sigtest.version>1.6</sigtest.version>
+        <sigtest.version>2.3</sigtest.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-            <version>${jakarta.concurrent.api.version}</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -81,7 +80,7 @@
         </dependency>
         
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
             <version>${sigtest.version}</version>
             <scope>provided</scope>
@@ -172,10 +171,6 @@
                     <name>signature</name>
                 </property>
             </activation>
-            <properties>
-                <!--Default assumed JDK version, can be overriden via -Dmajor.jdk.version=X -->
-                <jdk.major.version>11</jdk.major.version>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -193,7 +188,7 @@
                                         <artifactItem>
                                             <groupId>jakarta.enterprise.concurrent</groupId>
                                             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-                                            <version>${jakarta.concurrent.api.version}</version>
+                                            <version>${project.version}</version>
                                             <type>jar</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/concurrency-api</outputDirectory>
@@ -207,7 +202,7 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.netbeans.tools</groupId>
+                        <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
                         <version>${sigtest.version}</version>
                         <executions>
@@ -226,26 +221,6 @@
                             </packages>
                             <attach>false</attach>
                             <sigfile>${project.build.directory}/jakarta.enterprise.concurrent.sig_${project.version}</sigfile>
-                            <!-- Ensure that the signature file we generated will work for both JDK11 and JDK17 -->
-                            <ignoreJDKClasses>
-                                <include>java.util.Map</include>
-                                <include>java.lang.Object</include>
-                                <include>java.io.ByteArrayInputStream</include>
-                                <include>java.io.InputStream</include>
-                                <include>java.lang.Deprecated</include>
-                                <include>java.io.Writer</include>
-                                <include>java.io.OutputStream</include>
-                                <include>java.util.List</include>
-                                <include>java.util.Collection</include>
-                                <include>java.lang.instrument.IllegalClassFormatException</include>
-                                <include>javax.transaction.xa.XAException</include>
-                                <include>java.lang.annotation.Repeatable</include>
-                                <include>java.lang.InterruptedException</include>
-                                <include>java.lang.CloneNotSupportedException</include>
-                                <include>java.lang.Throwable</include>
-                                <include>java.lang.Thread</include>
-                                <include>java.lang.Enum</include>
-                            </ignoreJDKClasses>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/README.md
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/README.md
@@ -19,7 +19,7 @@ The plugin that generates the signature file has been copied below for reference
 
 ```xml
 <plugin>
-	<groupId>org.netbeans.tools</groupId>
+	<groupId>jakarta.tck</groupId>
 	<artifactId>sigtest-maven-plugin</artifactId>
 	<version>${sigtest.version}</version>
 	<executions>

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/SigTestDriver.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/SigTestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,26 +58,6 @@ public class SigTestDriver extends SignatureTestDriver {
 
 	private static final String EXCLUDE_JDK_CLASS_FLAG = "-IgnoreJDKClass";
 
-	  private static String[] excludeJdkClasses = {
-	          "java.util.Map", 
-	          "java.lang.Object",
-	          "java.io.ByteArrayInputStream",
-	          "java.io.InputStream",
-	          "java.lang.Deprecated",
-	          "java.io.Writer",
-	          "java.io.OutputStream",
-	          "java.util.List",
-	          "java.util.Collection",
-	          "java.lang.instrument.IllegalClassFormatException",
-	          "javax.transaction.xa.XAException",
-	          "java.lang.annotation.Repeatable",
-	          "java.lang.InterruptedException",
-	          "java.lang.CloneNotSupportedException",
-	          "java.lang.Throwable",
-	          "java.lang.Thread",
-	          "java.lang.Enum"
-	  };
-
 	// ---------------------------------------- Methods from SignatureTestDriver
 
 	@Override
@@ -135,10 +115,7 @@ public class SigTestDriver extends SignatureTestDriver {
 			command.add(subPackages[i]);
 		}
 
-		for (String jdkClassName : excludeJdkClasses) {
-			command.add(EXCLUDE_JDK_CLASS_FLAG);
-			command.add(jdkClassName);
-		}
+        command.add(EXCLUDE_JDK_CLASS_FLAG);
 
 		command.add(API_VERSION_FLAG);
 		command.add(info.getVersion());

--- a/tck/src/main/resources/ee/jakarta/tck/concurrent/spec/signature/jakarta.enterprise.concurrent.sig
+++ b/tck/src/main/resources/ee/jakarta/tck/concurrent/spec/signature/jakarta.enterprise.concurrent.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.0.0-SNAPSHOT
+#Version 3.0.4-SNAPSHOT
 
 CLSS public jakarta.enterprise.concurrent.AbortedException
 cons public init()
@@ -257,7 +257,6 @@ cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr java.lang.Throwable
-hfds serialVersionUID
 
 CLSS public abstract interface !annotation java.lang.FunctionalInterface
  anno 0 java.lang.annotation.Documented()
@@ -301,7 +300,6 @@ meth public void printStackTrace(java.io.PrintStream)
 meth public void printStackTrace(java.io.PrintWriter)
 meth public void setStackTrace(java.lang.StackTraceElement[])
 supr java.lang.Object
-hfds ZeroElementArray,ZeroStackTraceElementArray,cause,detailMessage,disableWritableStackTrace,serialVersionUID,stackTrace,suppressedExceptions,walkback
 
 CLSS public abstract interface java.lang.annotation.Annotation
 meth public abstract boolean equals(java.lang.Object)
@@ -362,7 +360,6 @@ cons protected init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr java.lang.Exception
-hfds serialVersionUID
 
 CLSS public abstract interface java.util.concurrent.Executor
 meth public abstract void execute(java.lang.Runnable)
@@ -426,8 +423,6 @@ meth public void execute(java.lang.Runnable)
 meth public void execute(java.util.concurrent.ForkJoinTask<?>)
 meth public void shutdown()
 supr java.util.concurrent.AbstractExecutorService
-hfds ADD_WORKER,COMMON_MAX_SPARES,COMMON_PARALLELISM,CTL,DEFAULT_COMMON_MAX_SPARES,DEFAULT_KEEPALIVE,DORMANT,FIFO,INITIAL_QUEUE_CAPACITY,MAXIMUM_QUEUE_CAPACITY,MAX_CAP,MODE,OWNED,QA,QLOCK,QUIET,RC_MASK,RC_SHIFT,RC_UNIT,SEED_INCREMENT,SHUTDOWN,SMASK,SP_MASK,SQMASK,SS_SEQ,STOP,SWIDTH,TC_MASK,TC_SHIFT,TC_UNIT,TERMINATED,TIMEOUT_SLOP,TOP_BOUND_SHIFT,UC_MASK,UNSIGNALLED,bounds,common,ctl,factory,indexSeed,keepAlive,mode,modifyThreadPermission,poolNumberSequence,saturate,stealCount,ueh,workQueues,workerNamePrefix
-hcls DefaultForkJoinWorkerThreadFactory,InnocuousForkJoinWorkerThreadFactory,WorkQueue
 
 CLSS public abstract interface static java.util.concurrent.ForkJoinPool$ForkJoinWorkerThreadFactory
  outer java.util.concurrent.ForkJoinPool


### PR DESCRIPTION
Fixes #392
Fixes #393

Alternative solution for continued support of the Concurrency 3.0 TCK for future LTS Java levels.
Start using the jakarta.tck signature test plugin which allows for blanket ignoring of jdk classes.

Tested using Open Liberty on Java 17 (semeru) and Java 21 (openjdk): 


```txt
********************************************************************************
product = Open Liberty 24.0.0.6 (wlp-1.0.91.202406061535)
java.home = /Library/Java/JavaVirtualMachines/semeru-17.jdk/Contents/Home
java.version = 17.0.7
java.runtime = IBM Semeru Runtime Open Edition (17.0.7+7)
os = Mac OS X (14.5; aarch64) (en_US)
********************************************************************************
...
[6/27/24, 16:04:34:148 CDT] 00000091 ee.jakarta.tck.concurrent.spec.signature.ConcurrencySigTest  I 
******************************************************
******************************************************
All package signatures passed.
  Passed packages listed below: 
    jakarta.enterprise.concurrent(static mode)
    jakarta.enterprise.concurrent(reflection mode)
    jakarta.enterprise.concurrent.spi(static mode)
    jakarta.enterprise.concurrent.spi(reflection mode)
******************************************************
******************************************************
```

```txt
********************************************************************************
product = Open Liberty 24.0.0.6 (wlp-1.0.91.202406061535)
java.home = /Library/Java/JavaVirtualMachines/openjdk-21.jdk/Contents/Home
java.version = 21
java.runtime = OpenJDK Runtime Environment (21+35-2513)
os = Mac OS X (14.5; aarch64) (en_US)
********************************************************************************
...
[6/27/24, 16:13:41:058 CDT] 0000004c ee.jakarta.tck.concurrent.spec.signature.ConcurrencySigTest  I 
******************************************************
******************************************************
All package signatures passed.
  Passed packages listed below: 
    jakarta.enterprise.concurrent(static mode)
    jakarta.enterprise.concurrent(reflection mode)
    jakarta.enterprise.concurrent.spi(static mode)
    jakarta.enterprise.concurrent.spi(reflection mode)
******************************************************
******************************************************
```
FYI - @scottmarlow