### PR TITLE
Ensure pulls and merges to RELEASE-3.1.1 run CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,13 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "main" ]
+    branches: 
+        - 'main'
+        - 'RELEASE-*'
   pull_request:
-    branches: [ "main" ]
+    branches:
+        - 'main'
+        - 'RELEASE-*'
 
 permissions:
   contents: read


### PR DESCRIPTION
This is the latest service release branch.  Ensure the CI build is run whenever a pull or merge is created.