### PR TITLE
Update concurrency 3.0 service stream parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.9</version>
     </parent>
 
     <groupId>jakarta.enterprise.concurrent</groupId>


### PR DESCRIPTION
Updates the parent pom for this project from 1.0.6 -> 1.0.9 in the 3.0 service branches.

This is required for our staging and release builds.
The nexus-staging-maven-plugin dependency from the parent project needs to be upgraded from 1.6.8 -> 1.6.13 to support Java modules. 

```
[ERROR] -----------------------------------------------------: Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible: module java.base does not "opens java.util" to unnamed module @46c3a14d
```