### PR TITLE
Ensure tck-distribution is generated in 3.0 service stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,9 @@
 
     <modules>
         <module>api</module>
+        <module>specification</module>
         <module>tck</module>
+        <module>tck-dist</module>
     </modules>
 
     <scm>

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -20,15 +20,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.6</version>
-        <relativePath />
+        <groupId>jakarta.enterprise.concurrent</groupId>
+        <artifactId>jakarta.enterprise.concurrent.parent</artifactId>
+        <version>3.0.4-SNAPSHOT</version>
     </parent>
 
-    <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>concurrency-spec</artifactId>
-    <version>3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Concurrency Specification</name>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.enterprise.concurrent</groupId>
         <artifactId>jakarta.enterprise.concurrent.parent</artifactId>
-        <version>3.0.3-SNAPSHOT</version>
+        <version>3.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.enterprise.concurrent-tck-dist</artifactId>


### PR DESCRIPTION
The TCK distribution needs to be available in the staging repository before it can be uploaded to the eclipse.org staging site.
We should start uploading the tck-dist and spec artifacts to maven such as we do for EE 11.