### PR TITLE
Ensure the ci-verify step passes between releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,6 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Analyze starters
-      run: mvn dependency:analyze --file tck-dist/src/main/starter/pom.xml
+      # Note: the starter is always 1 version ahead of what is in maven central
+      # therefore, when we analyze the starters we need to force a prior version
+      run: mvn dependency:analyze -Djakarta.concurrent.version=3.1.1 --file tck-dist/src/main/starter/pom.xml

--- a/tck-dist/src/main/starter/pom.xml
+++ b/tck-dist/src/main/starter/pom.xml
@@ -34,7 +34,7 @@
         <maven.compiler.target>21</maven.compiler.target>
 
         <!-- Dependency and Plugin Versions -->
-        <jakarta.concurrent.version>3.1.1</jakarta.concurrent.version>
+        <jakarta.concurrent.version>3.2.0</jakarta.concurrent.version>
         <jakarta.servlet.version>6.1.0</jakarta.servlet.version>
 
         <junit5.version>5.11.0</junit5.version>


### PR DESCRIPTION
Starter pom in the main branch represents the next release of concurrency.
Our verification step during ci builds will force the use of the latest version available in maven central.