### PR TITLE
Correction to whitespace typo in currentContextExecutor

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
@@ -484,7 +484,7 @@ public interface ContextService {
   /**
    * <p>Captures thread context as an {@link java.util.concurrent.Executor}
    * that runs tasks on the same thread from which
-   * <code>execute</code>is invoked but with context that is captured from the thread
+   * <code>execute</code> is invoked but with context that is captured from the thread
    * that invokes <code>currentContextExecutor</code>.</p>
    *
    * <p>Example usage:</p>


### PR DESCRIPTION
Another case of reading through some of our Javadoc to answer a question where I noticed a minor typo.  In this case, missing space to separate `execute` from "is",

https://jakarta.ee/specifications/platform/10/apidocs/jakarta/enterprise/concurrent/contextservice#currentContextExecutor()