### PR TITLE
Ignore: jruby 10.0.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     labels:
       - "dependencies"
       - "bot"
+    ignore:
+      #TODO wait until we are building with Java 21 and Asciidoctor is updated to support jruby 10
+      - dependency-name: "org.jruby:jruby"
+      - versions: [ ">10.0.0.0" ]
 
   - package-ecosystem: maven
     directory: /tck-dist/src/main/starter/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     ignore:
       #TODO wait until we are building with Java 21 and Asciidoctor is updated to support jruby 10
       - dependency-name: "org.jruby:jruby"
-      - versions: [ ">10.0.0.0" ]
+        versions: [ "[10,)" ]
 
   - package-ecosystem: maven
     directory: /tck-dist/src/main/starter/


### PR DESCRIPTION
Fixes #704

Asciidoctor does not yet support jruby 10.  See error: 

```
Error:  Failed to execute goal org.asciidoctor:asciidoctor-maven-plugin:3.2.0:process-asciidoc (asciidoc-to-pdf) on project jakarta.data-tck-dist: Execution asciidoc-to-pdf of goal org.asciidoctor:asciidoctor-maven-plugin:3.2.0:process-asciidoc failed: (ArgumentError) wrong number of arguments (given 3, expected 1..2): (LoadError) no such file to load -- asciidoctor-pdf -> [Help 1]
```