### PR TITLE
remove Java SE 17 references from Javadoc

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -229,11 +229,6 @@ public @interface ManagedExecutorDefinition {
      * another stage or a join operation on the completion stage.
      * In situations such as these, the executor does not control
      * the type of thread that is used to run the task.</p>
-     *
-     * <p>When running on Java SE 17, the {@code true} value
-     * behaves the same as the {@code false} value and results in
-     * platform threads being created rather than virtual threads.
-     * </p>
      *
      * @return {@code true} if the executor can create virtual threads,
      *         otherwise {@code false}.

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -230,11 +230,6 @@ public @interface ManagedScheduledExecutorDefinition {
      * another stage or a join operation on the completion stage.
      * In situations such as these, the executor does not control
      * the type of thread that is used to run the task.</p>
-     *
-     * <p>When running on Java SE 17, the {@code true} value
-     * behaves the same as the {@code false} value and results in
-     * platform threads being created rather than virtual threads.
-     * </p>
      *
      * @return {@code true} if the executor can create virtual threads,
      *         otherwise {@code false}.

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -202,11 +202,6 @@ public @interface ManagedThreadFactoryDefinition {
      * thread factory must not create virtual threads.
      * When {@code false}, the thread factory always creates
      * platform threads.</p>
-     *
-     * <p>When running on Java SE 17, the {@code true} value
-     * behaves the same as the {@code false} value and results in
-     * platform threads being created rather than virtual threads.
-     * </p>
      *
      * @return {@code true} if the thread factory is requested to
      *         create virtual threads, otherwise {@code false}.


### PR DESCRIPTION
fixes #675

Remove references to Java SE 17 from Javadoc given that the minimum Java level will be Java SE 21 in Concurrency 3.2.  These references were all in Javadoc relating to virtual threads, which are not available in Java SE 17 and needed special language when Java SE 17 was a supported Java level for Concurrency 3.1.