### PR TITLE
improve doc of schedule with trigger

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,9 @@
 
 package jakarta.enterprise.concurrent;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 
 /**
  * A manageable version of a {@link java.util.concurrent.ScheduledExecutorService}.<p>
@@ -135,8 +137,15 @@ public interface ManagedScheduledExecutorService extends
     ManagedExecutorService, ScheduledExecutorService {
 
   /**
-   * Creates and executes a task based on a Trigger. The Trigger determines when the task
-   * should run and how often.
+   * <p>Creates and executes a task based on a {@link Trigger}. The
+   * {@code Trigger} determines when the task should run and how often.</p>
+   *
+   * <p>Prior to completion of all executions of the task, the state of the
+   * {@link ScheduledFuture} changes to represent the currently scheduled or
+   * running execution of the task. After completion of all executions, its
+   * state represents completion of the final execution. Future and past
+   * executions are otherwise not represented by the {@code ScheduledFuture}.
+   * </p>
    *
    * @param command the task to execute.
    * @param trigger the trigger that determines when the task should fire.
@@ -147,24 +156,32 @@ public interface ManagedScheduledExecutorService extends
    * @throws java.util.concurrent.RejectedExecutionException if task cannot be scheduled for execution.
    * @throws java.lang.NullPointerException if command is null.
    */
-  public java.util.concurrent.ScheduledFuture<?> schedule(java.lang.Runnable command,
-                                                          Trigger trigger);
+  public ScheduledFuture<?> schedule(Runnable command,
+                                     Trigger trigger);
   
   /**
-   * Creates and executes a task based on a Trigger. The Trigger determines when the task should
-   * run and how often.
+   * <p>Creates and executes a task based on a {@link Trigger}. The
+   * {@code Trigger} determines when the task should run and how often.</p>
+   *
+   * <p>Prior to completion of all executions of the task, the state of the
+   * {@link ScheduledFuture} changes to represent the currently scheduled or
+   * running execution of the task. After completion of all executions, its
+   * state represents completion of the final execution. Future and past
+   * executions are otherwise not represented by the {@code ScheduledFuture}.
+   * Multiple results can be expected when there are multiple of executions
+   * of the task.</p>
    *
    * @param callable the function to execute.
    * @param trigger the trigger that determines when the task should fire.
    * @param <V> the return type of the <code>Callable</code>
    *
-   * @return a ScheduledFuture that can be used to extract result or cancel.
+   * @return a ScheduledFuture that can be used to extract a result or cancel.
    *
    * @throws java.util.concurrent.RejectedExecutionException if task cannot be scheduled for execution.
    * @throws java.lang.NullPointerException if callable is null.
    *
    */
-  public <V> java.util.concurrent.ScheduledFuture<V> schedule(java.util.concurrent.Callable<V> callable,
-                                                              Trigger trigger);
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable,
+                                         Trigger trigger);
 
 }


### PR DESCRIPTION
Fixes #37 which states that

> The behavior of calling get() on the ScheduledFuture returned by ManagedScheduledExecutorService.schedule() with a Trigger is not clearly defined in both the spec and javadoc.

Actually, the behavior is clearly defined in the [ManagedScheduledExecutorService Javadoc](https://jakarta.ee/specifications/concurrency/3.1/apidocs/jakarta.concurrency/jakarta/enterprise/concurrent/managedscheduledexecutorservice), where it says: 

> Tasks can be scheduled to run periodically using the schedule methods that take a Trigger as an argument and the scheduleAtFixedRate and scheduleWithFixedDelay methods. The result of the Future will be represented by the currently scheduled or running instance of the task. Future and past executions of the task are not represented by the Future. The state of the Future will therefore change and multiple results are expected.

This probably went unnoticed to whomever opened #37 because it is placed within the class description rather than the method description.  This PR adds the same information to the schedule methods that accept Trigger in order to address the concern.
