### PR TITLE
update: parent project to M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0-M1</version>
     </parent>
 
     <groupId>jakarta.enterprise.concurrent</groupId>
@@ -64,20 +64,6 @@
         <developerConnection>scm:git:git@github.com:jakartaee/concurrency.git</developerConnection>
         <url>https://github.com/jakartaee/concurrency</url>
     </scm>
-
-    <repositories>
-        <repository>
-            <name>Central Portal Snapshots</name>
-            <id>central-portal-snapshots</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Release notes: https://github.com/eclipse-ee4j/ee4j/releases/tag/2.0.0-M1
I'll wait to do the M1 release of Concurrency until this is merged to save us the headache of having to update the SNAPSHOT version of the parent later in the service branch. 