### PR TITLE
Lock annotation like the EJB lock annotation, but for CDI beans

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -93,12 +93,18 @@ public @interface Lock {
     @Nonbinding Type type() default Type.WRITE;
 
     /**
+     * <p>The maximum amount of time to wait to obtain the lock.
+     * If the lock that allows running the method cannot be obtained within
+     * the specified amount of time, a {@link java.util.concurrent.CompletionException}
+     * that chains a {@link java.util.concurrent.TimeoutException} is thrown
+     * from the method invocation attempt.</p>
      *
-     * @return the way to deal with time out waiting for a lock
-     */
-    @Nonbinding TimeoutType timeoutType() default TimeoutType.TIMEOUT;
-
-    /**
+     * <p>Use the {@link #IMMEDIATE} constant to avoid waiting.</p>
+     *
+     * <p>Use the {@link #UNLIMITED} constant to avoid timing out.</p>
+     *
+     * <p>The supplied timeout value must be positive or one of the constants
+     * described above.</p>
      *
      * @return the time to wait to obtain a lock
      */


### PR DESCRIPTION
Addressing #135 

A lock annotation in the spirit of the EJB lock annotation, but specifically for CDI beans. This is directly based on the similarly named annotation that already exists in Concurro and has functionality implemented for it.