### PR TITLE
Pooled annotation like in EJB @Stateless, but for CDI beans

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Pooled.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Pooled.java
@@ -244,6 +244,7 @@ public @interface Pooled {
                         final Class<? extends Throwable>[]    keepOn
             ) {
 
+            requireNonNull(unit, "unit: null");
             requireNonNull(destroyOn, "destroyOn: null");
             requireNonNull(keepOn, "keepOn: null");
 


### PR DESCRIPTION
Addressing https://github.com/jakartaee/concurrency/issues/136

A pooled annotation in the spirit of one of the properties of the EJB @Stateless, but specifically for CDI beans. This is directly based on the similarly named annotation that already exists in Concurro and has functionality implemented for it.