### PR TITLE
Lock.Literal.of missing javadoc and allows nulls

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -162,7 +162,7 @@ public @interface Lock {
         }
 
         /**
-         * {@return the Lock.Type to use.}
+         * {@return the Lock.Type to use}
          */
         @Override
         public Type type() {
@@ -170,7 +170,7 @@ public @interface Lock {
         }
 
         /**
-         * {@return the time to wait to obtain a lock.}
+         * {@return the time to wait to obtain a lock}
          */
         @Override
         public long accessTimeout() {
@@ -178,7 +178,7 @@ public @interface Lock {
         }
 
         /**
-         * {@return units used for the specified accessTimeout value.}
+         * {@return units used for the specified accessTimeout value}
          */
         @Override
         public TimeUnit unit() {


### PR DESCRIPTION
Fixes the following issues:

- Lock.Literal.of method was missing Javadoc.
- Lock.Literal.of method allowed `null` values that aren't permitted by the `@Lock` annotation.
- several other methods of Lock.Literal have a description sentence ending in `..` rather than `.`