### PR TITLE
Correction to taskStarting Javadoc

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -213,8 +213,9 @@ public interface ManagedTaskListener {
 
   /**
    * This method is called before the task is about to start. The task will
-   * not enter the starting state until the taskSubmitted listener has completed. This method
-   * may be called from the same thread that the task was submitted with.
+   * not enter the starting state until the {@code taskStarting} listener has
+   * completed. This method may be called from the same thread that runs the
+   * task.
    *
    * @param future the {@link Future} instance that was created when the task was submitted.
    * @param executor the executor used to run the associated Future.


### PR DESCRIPTION
The second and third sentences of [ManagedTaskListener.taskStarting](https://jakarta.ee/specifications/concurrency/3.1/apidocs/jakarta.concurrency/jakarta/enterprise/concurrent/managedtasklistener#taskStarting(java.util.concurrent.Future,jakarta.enterprise.concurrent.ManagedExecutorService,java.lang.Object)) look like they were copied/pasted from [ManagedTaskListener.taskSubmitted](https://jakarta.ee/specifications/concurrency/3.1/apidocs/jakarta.concurrency/jakarta/enterprise/concurrent/managedtasklistener#taskSubmitted(java.util.concurrent.Future,jakarta.enterprise.concurrent.ManagedExecutorService,java.lang.Object)) and never updated for the `taskStarting` method.  Although the copied information is also true, it is not very helpful.  This PR updates the Javadoc to what should have been there, per the the state diagram which shows `taskStarting` happening before calling `run` on the task, with the opportunity for the `taskStarting` implementation to cancel the task's `Future` before the task runs.
