### PR TITLE
feat: add java 25 to ci and update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ '21' ] # TODO add 25
+        java-version: [ '21', '25' ]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java-version: ['21'] # TODO add 25
+        java-version: ['21', '25']
 
     steps:
     - name: Checkout source


### PR DESCRIPTION
Related: https://github.com/jakartaee/concurrency/pull/859

Allow action to generate Java 25 signatures