### PR TITLE
Missing Javadoc for Lock unit

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -111,8 +111,9 @@ public @interface Lock {
     @Nonbinding long accessTimeout() default 60;
 
     /**
+     * Time unit of the {@link #accessTimeout() accessTimeout}.
      *
-     * @return units used for the specified accessTimeout value.
+     * @return units used for the specified {@code accessTimeout} value.
      */
     @Nonbinding TimeUnit unit() default SECONDS;
 


### PR DESCRIPTION
When viewing the Javadoc for `Lock`, `unit` shows up without any description.  This PR adds a description.