### PR TITLE
refactor: avoid using Maven.resolver() in TCK

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKArchiveProcessor.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKArchiveProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,7 +15,6 @@
  */
 package ee.jakarta.tck.concurrent.framework.arquillian.extensions;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
@@ -32,7 +31,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.impl.base.asset.AssetUtil;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
 import ee.jakarta.tck.concurrent.common.signature.ConcurrencySignatureTestRunner;
 import ee.jakarta.tck.concurrent.framework.junit.anno.Common;
@@ -108,9 +106,8 @@ public class TCKArchiveProcessor implements ApplicationArchiveProcessor {
             ((ClassContainer<?>) applicationArchive).addPackage(signaturePackage);
 
             // Add the sigtest plugin library
-            File sigTestDep = Maven.resolver().resolve("jakarta.tck:sigtest-maven-plugin:2.3").withoutTransitivity().asSingleFile();
-            log.info("Application Archive [" + applicationName + "] is being appended with library " + sigTestDep.getName());
-            ((LibraryContainer<?>) applicationArchive).addAsLibrary(sigTestDep);
+            log.info("Application Archive [" + applicationName + "] is being appended with library sigtest-maven-plugin.jar");
+            ((LibraryContainer<?>) applicationArchive).addAsLibrary(TCKDependencyProcessor.SigTestArchive.get());
             
             // Add signature resources
             log.info("Application Archive [" + applicationName + "] is being appended with resources "

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKDependencyProcessor.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKDependencyProcessor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.framework.arquillian.extensions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Objects;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Logger;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+public class TCKDependencyProcessor {
+
+    private static final Logger log = Logger.getLogger(TCKDependencyProcessor.class.getCanonicalName());
+    
+    // Add any additional deployment dependencies here (for example AssertJ) as a nested
+    // class that extends CachedAuxilliaryArchiveAppender
+    
+    /**
+     * An archive appender that get's applied selectively in the
+     * {@link TCKArchiveProcessor#process(Archive, org.jboss.arquillian.test.spi.TestClass)} method.
+     */
+    public static final class SigTestArchive {
+
+        private static Archive<?> instance;
+        
+        private SigTestArchive() {
+            // Only access via static method
+        }
+        
+        private static Archive<?> buildArchive() {
+            final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "sigtest-maven-plugin.jar");
+            archive.addPackages(true, "com.sun.tdk");
+            archive.addPackages(true, "org.netbeans.apitest");
+            archive.addPackages(true, "jakarta.tck.sigtest_maven_plugin");
+            
+            addManifestDirectoryResources(archive, "com.sun.tdk.signaturetest.Version");
+            
+            log.info("Recreated sigtest-maven-plugin.jar archive with contents: " + archive.toString(true));
+            
+            instance = archive;
+            
+            return instance;
+        }
+        
+        public static Archive<?> get() {
+            return Objects.requireNonNullElseGet(instance, () -> buildArchive());
+        }
+        
+    }
+
+
+    /**
+     * Adds all META-INF directory resources from the JAR file containing the specified
+     * reference class to the provided archive. This is used to preserve manifest and
+     * service provider configuration files when recreating dependency archives.
+     *
+     * @param archive the JavaArchive to add META-INF resources to
+     * @param refClass the fully qualified name of a class within the source JAR
+     * @throws RuntimeException if the reference class cannot be found, is not loaded
+     *         from a JAR file, or if an I/O error occurs while copying resources
+     */
+    private static void addManifestDirectoryResources(final JavaArchive archive, final String refClass) {
+
+       // Get classloader to reference class
+       ClassLoader artifactClassloader;
+       try {
+          artifactClassloader = Class.forName(refClass).getClassLoader();
+       } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Could not find reference class for assertj", e);
+        }
+       
+       // Construct reference resource
+       String refResrouce = refClass.replace('.', '/') + ".class";
+       
+        try {
+           
+           // Find artifact's location on the file system and verify it's a JAR
+            URL classUrl = artifactClassloader.getResource(refResrouce);
+            if (classUrl == null) {
+                throw new RuntimeException("Could not locate reference class resource for " + refClass);
+            }
+            if (!"jar".equals(classUrl.getProtocol())) {
+                throw new RuntimeException("Expected " + archive.getName()
+                                           + " classes to be loaded from a jar but found protocol: " + classUrl.getProtocol());
+            }
+
+            // Add all META-INF/ resources to the re-create archive
+            JarURLConnection connection = (JarURLConnection) classUrl.openConnection();
+            try (JarFile jarFile = connection.getJarFile()) {
+                Enumeration<JarEntry> entries = jarFile.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    if (!entry.isDirectory() && entry.getName().startsWith("META-INF/")) {
+                        try (InputStream input = jarFile.getInputStream(entry)) {
+                            archive.add(new ByteArrayAsset(input.readAllBytes()), entry.getName());
+                        }
+                    }
+                }
+            }
+            
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to copy META-INF resources into recreated archive", e);
+        }
+    }
+    
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKFrameworkAppender.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKFrameworkAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,9 +15,7 @@
  */
 package ee.jakarta.tck.concurrent.framework.arquillian.extensions;
 
-import java.util.logging.Logger;
-
-import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -36,27 +34,15 @@ import ee.jakarta.tck.concurrent.framework.junit.extensions.AssertionExtension;
  * Package - ee.jakarta.tck.concurrent.framework.junit.extensions
  *
  */
-public class TCKFrameworkAppender implements AuxiliaryArchiveAppender {
-
-    private static final Logger log = Logger.getLogger(TCKFrameworkAppender.class.getCanonicalName());
-
+public class TCKFrameworkAppender extends CachedAuxilliaryArchiveAppender {
+    
     private static final Package utilPackage = TestServlet.class.getPackage();
     private static final Package annoPackage = Common.class.getPackage();
     private static final Package extePackage = AssertionExtension.class.getPackage();
 
-    private static final String archiveName = "jakarta-concurrent-framework.jar";
-
-    private static JavaArchive framework = null;
-
     @Override
-    public Archive<?> createAuxiliaryArchive() {
-        if (framework != null) {
-            return framework;
-        }
-
-        log.info("Creating auxiliary archive: " + archiveName);
-
-        framework = ShrinkWrap.create(JavaArchive.class, archiveName);
+    public Archive<?> buildArchive() {
+        JavaArchive framework = ShrinkWrap.create(JavaArchive.class, "jakarta-concurrent-framework.jar");
         framework.addPackages(false, utilPackage, annoPackage, extePackage);
         return TestPropertyHandler.storeProperties(framework);
     }

--- a/tck/src/test/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKArchiveProcessorTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/concurrent/framework/arquillian/extensions/TCKArchiveProcessorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.framework.arquillian.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.path.BasicPath;
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.concurrent.framework.junit.anno.Common;
+import ee.jakarta.tck.concurrent.framework.junit.anno.Signature;
+import ee.jakarta.tck.concurrent.framework.junit.anno.Web;
+
+public class TCKArchiveProcessorTest {
+    private static final TCKArchiveProcessor processor = new TCKArchiveProcessor();
+    
+    @Web
+    @Common(Common.PACKAGE.TASKS)
+    private static class TestWebClass {}
+    
+    @Test
+    public void processorShouldAppendServletFrameworkForWebArchives() {
+        WebArchive testWAR = ShrinkWrap.create(WebArchive.class);
+        assertTrue(testWAR.getContent().isEmpty());
+        
+        processor.process(testWAR, new TestClass(TestWebClass.class));
+        assertFalse(testWAR.getContent().isEmpty());
+        
+        // Should append task packages    
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/concurrent/common/tasks")));    
+        
+        // Should not append signature packages
+        assertFalse(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/concurrent/common/signature")));
+    }
+    
+    @Signature
+    private static class TestSignatureClass {}
+    
+    @Test
+    public void processorShouldAppendSignatureFrameworkForSignatureArchvies() {
+        WebArchive testWAR = ShrinkWrap.create(WebArchive.class);
+        assertTrue(testWAR.getContent().isEmpty());
+        
+        processor.process(testWAR, new TestClass(TestSignatureClass.class));
+        assertFalse(testWAR.getContent().isEmpty());
+        
+        // Should not append framework packages    
+        assertFalse(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/concurrent/framework")));    
+        
+        // Should append signature packages
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/concurrent/common/signature")));
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/lib/sigtest-maven-plugin.jar")));
+    }
+
+    @Test
+    public void sigTestArchiveShouldIncludePluginClassesAndSignatureResources() {
+        assertNotNull(TCKDependencyProcessor.SigTestArchive.get());
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/com/sun/tdk/signaturetest/SigTest.class")));
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/org/netbeans/apitest/Sigtest.class")));
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/jakarta/tck/sigtest_maven_plugin/HelpMojo.class")));
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/META-INF/MANIFEST.MF")));
+    }
+}


### PR DESCRIPTION
- No need to update source code for new versions, instead find dependencies for TCK via runner's classpath
- Avoid pulling from maven central, when runner might be running on a system that pulls artifacts from a mirror.
- Avoid maven central rate limits.
- Create unit test for TCK test infrastructure