### PR TITLE
Define loopback behavior for Lock annotation

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -54,18 +54,29 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public @interface Lock {
 
     /**
-     * Designates the type of lock to be READ or WRITE.
+     * Designates the type of lock to be {@link READ} or {@link WRITE}.
      */
     enum Type {
         /**
          * For read-only operations. Allows simultaneous access, as long as no
-         * <code>WRITE</code> lock is held.
+         * other thread holds a <code>WRITE</code> lock on the bean.
          */
         READ,
 
         /**
-         * For exclusive access to the bean instance. A <code>WRITE</code> lock can only be acquired when no other method with
-         * either a <code>READ</code> or <code>WRITE</code> lock is currently held.
+         * For exclusive access to the bean instance. A <code>WRITE</code>
+         * lock can only be acquired when no thread holds a <code>READ</code>
+         * or <code>WRITE</code> lock on the bean.
+         * <p>
+         * A thread that already holds a {@code READ} lock does not upgrade
+         * to a {@code WRITE} lock on the bean. Instead, the bean method
+         * raises {@link IllegalStateException} to the caller.
+         * <p>
+         * A thread that already holds a {@code WRITE} lock for purposes
+         * of running a bean method, and from the bean method either
+         * directly or indirectly invokes a method of the bean, does so
+         * under the same lock rather than acquiring an additional lock on
+         * the bean.
          */
         WRITE
     }


### PR DESCRIPTION
Adds language to the Javadoc of `@Lock` addressing what happens when a method invokes another method of a bean that has a lock, taking into account the possibility that the lock and requested lock might differ in READ vs WRITE mode.

The discussion of this was started by @arjantijms in https://github.com/jakartaee/concurrency/issues/135#issuecomment-4923634307 of issue #135 .  In the subsequent comments we decided that an attempt to upgrade from READ to WRITE should fail fast.