### PR TITLE
LockTimeoutException for when Lock times out

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -84,8 +84,7 @@ public @interface Lock {
     /**
      * Value for {@link #accessTimeout} that indicates that the lock that
      * permits running a bean method must be obtained immediately.
-     * Otherwise, a {@link java.util.concurrent.CompletionException} that
-     * chains a {@link java.util.concurrent.TimeoutException} is thrown.
+     * Otherwise, a {@link LockTimeoutException} is thrown.
      */
     long IMMEDIATE = 0;
 
@@ -106,8 +105,7 @@ public @interface Lock {
     /**
      * <p>The maximum amount of time to wait to obtain the lock.
      * If the lock that allows running the method cannot be obtained within
-     * the specified amount of time, a {@link java.util.concurrent.CompletionException}
-     * that chains a {@link java.util.concurrent.TimeoutException} is thrown
+     * the specified amount of time, a {@link LockTimeoutException} is thrown
      * from the method invocation attempt.</p>
      *
      * <p>Use the {@link #IMMEDIATE} constant to avoid waiting.</p>

--- a/api/src/main/java/jakarta/enterprise/concurrent/LockTimeoutException.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/LockTimeoutException.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+/**
+ * Indicates that a {@link Lock} could not be obtained within the allotted
+ * {@linkplain Lock#accessTimeout access timeout}.
+ *
+ * @since 3.2
+ */
+public class LockTimeoutException extends RuntimeException {
+    private static final long serialVersionUID = -9021472677315027139L;
+
+    /**
+     * Constructs a {@code LockTimeoutException} without providing a detail
+     * message or cause.
+     */
+    public LockTimeoutException() {
+        super();
+    }
+
+    /**
+     * Constructs a {@code LockTimeoutException} with the given detail message.
+     *
+     * @param message the {@linkplain Throwable#getMessage() detail message}
+     */
+    public LockTimeoutException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a {@code LockTimeoutException} with the given detail message
+     * and cause.
+     *
+     * @param message the {@linkplain Throwable#getMessage() detail message}
+     * @param cause   the {@linkplain Throwable#getCause() cause}. A
+     *                {@code null} value indicates an unknown or nonexistent
+     *                cause
+     */
+    public LockTimeoutException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a {@code LockTimeoutException} with the given cause. The
+     * detail message is obtained from {@code cause.toString()} or, if
+     * the cause is {@null}, remains {@null}.
+     *
+     * @param cause the {@linkplain Throwable#getCause() cause}. A {@code null}
+     *              value indicates an unknown or nonexistent cause
+     */
+    public LockTimeoutException(final Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
fixes #912 by introducing `LockTimeoutException` covering the scenario where a Lock cannot be obtained within the period specified by its `accessTimeout`.