### PR TITLE
when neither method nor bean is annotated Lock, but some other bean method is

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -40,10 +40,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  *
  * <p>A bean method that does not have a {@code Lock} annotation inherits
  * the {@code Lock} annotation, if present, of the class that declares the method.
- * A bean class that has a method annotated {@code Lock}, but does not have a
- * {@code Lock} annotation of its own at the class level, operates according to
- * the default values of the {@code Lock} annotation when bean methods that are
- * not annotated {@code Lock} are invoked.</p>
+ * If neither the bean method nor the bean class are annotated {@code Lock},
+ * then invocation of the method does not require a lock to be obtained.</p>
  *
  * @since 3.2
  */


### PR DESCRIPTION
The Javadoc for Lock currently has an odd requirement (which was probably my fault when adding documentation to the original contribution) that requires an unannotated method on an unannotated bean to operate as though it has the `@Lock()` annotation defaults if some other method of the bean has a `Lock` annotation.  This will be surprising to users, is inconsistent with how interceptors work, and also prevents a useful behavior of being able to have some methods that are not subject to locking.

This PR switches the requirement to the expected behavior of no locking implied when neither the method nor its bean has a `Lock` annotation.