### PR TITLE
fix: typo in tck starter

### DIFF
--- a/tck-dist/src/main/starter/pom.xml
+++ b/tck-dist/src/main/starter/pom.xml
@@ -220,7 +220,7 @@
                     <excludedGroups>${test.excluded.groups}</excludedGroups> <!-- Groups to ignore i.e. signature -->
                     <!-- Ensure surfire plugin looks under src/main/java instead of src/test/java -->
                     <testSourceDirectory>
-                        ${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}
+                        ${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}
                     </testSourceDirectory>
                 </configuration>
             </plugin>

--- a/tck-dist/src/main/starter/pom.xml
+++ b/tck-dist/src/main/starter/pom.xml
@@ -218,10 +218,6 @@
                     </systemPropertyVariables>
                     <groups>${test.included}</groups>                        <!-- Groups to include i.e. web/platform -->
                     <excludedGroups>${test.excluded.groups}</excludedGroups> <!-- Groups to ignore i.e. signature -->
-                    <!-- Ensure surfire plugin looks under src/main/java instead of src/test/java -->
-                    <testSourceDirectory>
-                        ${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}
-                    </testSourceDirectory>
                 </configuration>
             </plugin>
             <!-- end::configSurefire[] -->


### PR DESCRIPTION
minor typo.
but according to the documentation the surefire plugin only uses testSourceDirectory for testNG so let's just remove this: https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#testSourceDirectory