### PR TITLE
Lock wait interrupted

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -105,9 +105,9 @@ public @interface Lock {
     /**
      * <p>The maximum amount of time to wait to obtain the lock.</p>
      *
-     * <p>If the lock that allows running the method cannot be obtained within
-     * the specified amount of time, a {@link LockTimeoutException} is thrown
-     * from the method invocation attempt.</p>
+     * <p>If the lock that controls access to the method cannot be obtained
+     * within the specified amount of time, a {@link LockTimeoutException}
+     * is thrown from the method invocation attempt.</p>
      *
      * <p>If the thread is interrupted while awaiting the lock, and the bean
      * method declares that it throws {@link InterruptedException}, then

--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -103,10 +103,19 @@ public @interface Lock {
     @Nonbinding Type type() default Type.WRITE;
 
     /**
-     * <p>The maximum amount of time to wait to obtain the lock.
-     * If the lock that allows running the method cannot be obtained within
+     * <p>The maximum amount of time to wait to obtain the lock.</p>
+     *
+     * <p>If the lock that allows running the method cannot be obtained within
      * the specified amount of time, a {@link LockTimeoutException} is thrown
      * from the method invocation attempt.</p>
+     *
+     * <p>If the thread is interrupted while awaiting the lock, and the bean
+     * method declares that it throws {@link InterruptedException}, then
+     * {@code InterruptedException} is raised to the caller.
+     * If the thread is interrupted while awaiting the lock, but the bean
+     * does not declare that it throws {@code InterruptedException}, then an
+     * {@link IllegalStateException} that chains {@code InterruptedException}
+     * is raised to the caller.</p>
      *
      * <p>Use the {@link #IMMEDIATE} constant to avoid waiting.</p>
      *


### PR DESCRIPTION
We need to define what happens when a bean method is interrupted while awaiting a Lock.  It is likely obvious what to do if the bean method signature declares that it throw InterruptedException, but not all bean methods will declare InterruptedException.  This PR proposes that when InterruptedException is not declared by the method, then it raises IllegalStateException with a chained InterruptedException.