### PR TITLE
Interceptor priority for Lock

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>jakarta.cdi-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -165,6 +170,11 @@ Copyright &#169; 2020, ${current.year} Eclipse Foundation. All rights reserved.<
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
                             </bottom>
                             <docfilessubdirs>true</docfilessubdirs>
+                            <links>
+                                <link>https://jakarta.ee/specifications/interceptors/2.2/apidocs/</link>
+                                <link>https://jakarta.ee/specifications/transactions/2.0/apidocs/</link>
+                                <!-- TODO switch the above to transactions/2.1 for EE 12 once it exists -->
+                            </links>
                             <groups>
                                 <group>
                                     <title>Jakarta Concurrency API Documentation</title>

--- a/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
@@ -28,7 +28,9 @@ import java.util.concurrent.CompletableFuture;
 
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InterceptorBinding;
+import jakarta.transaction.Transactional;
 
 /**
  * Annotates a CDI managed bean method to run asynchronously.
@@ -168,17 +170,24 @@ import jakarta.interceptor.InterceptorBinding;
  *
  * <h2>Interceptor and Transactional</h2>
  *
- * The Jakarta EE Product Provider must assign the interceptor for asynchronous methods
- * to have priority of <code>Interceptor.Priority.PLATFORM_BEFORE + 5</code>.
- * Interceptors with a lower priority, such as <code>Transactional</code>, must run on
- * the thread where the asynchronous method executes, rather than on the submitting thread.
- * When an asynchronous method is annotated as <code>Transactional</code>,
+ * When an asynchronous method is annotated as {@link Transactional},
  * the transactional types which can be used are:
- * <code>TxType.REQUIRES_NEW</code>, which causes the method to run in a new transaction, and
- * <code>TxType.NOT_SUPPORTED</code>, which causes the method to run with no transaction.
- * All other transaction attributes must result in
- * {@link java.lang.UnsupportedOperationException UnsupportedOperationException}
+ * <ul>
+ * <li>{@link Transactional.TxType#REQUIRES_NEW REQUIRES_NEW},
+ * which causes the method to run in a new transaction, and</li>
+ * <li>{@link Transactional.TxType#NOT_SUPPORTED NOT_SUPPORTED},
+ * which causes the method to run with no transaction.</li>
+ * </ul>
+ * All other transaction attributes must result in {@link
+ * java.lang.UnsupportedOperationException UnsupportedOperationException}
  * upon invocation of the asynchronous method.
+ *
+ * <p>
+ * The Jakarta EE Product Provider must assign the {@code @Asynchronous}
+ * interceptor a priority of {@link Interceptor.Priority#PLATFORM_BEFORE}
+ * {@code + 5}. Interceptors with a lower priority, such as {@link Lock @Lock}
+ * and {@link Transactional @Transactional}, must run on the thread where the
+ * asynchronous method executes, rather than on the submitting thread.
  *
  * @since 3.0
  */

--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -43,6 +43,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * If neither the bean method nor the bean class are annotated {@code Lock},
  * then invocation of the method does not require a lock to be obtained.</p>
  *
+ * <p>The Jakarta EE Product Provider must assign the {@code @Lock} interceptor
+ * a priority of {@link jakarta.interceptor.Interceptor.Priority#PLATFORM_BEFORE}
+ * {@code + 100}.</p>
+ *
  * @since 3.2
  */
 @InterceptorBinding

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,4 +19,5 @@ module jakarta.concurrency {
 
     requires jakarta.interceptor;
     requires jakarta.cdi;
+    requires static jakarta.transaction; // compile time dependency for Javadoc
 }

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,8 @@
         <jakarta.concurrency.version>${project.version}</jakarta.concurrency.version>
         <jakarta.ejb.version>4.0.1</jakarta.ejb.version>
         <jakarta.interceptor.version>2.2.0</jakarta.interceptor.version>
+        <!-- TODO switch the following to 2.1.0 for EE 12 once it exists -->
+        <jakarta.transaction.version>2.0.1</jakarta.transaction.version>
         <jakarta.jsp.version>4.1.0-M2</jakarta.jsp.version>
         <jakarta.servlet.version>6.2.0-M2</jakarta.servlet.version>
     </properties>
@@ -197,6 +199,12 @@
                 <groupId>jakarta.cdi</groupId>
                 <artifactId>jakarta.cdi-api</artifactId>
                 <version>${jakarta.cdi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>${jakarta.transaction.version}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
We need to define a priority for the Lock interceptor so that behavior is consistent across implementations.
The following is how we defined the priority for the other interceptor (`@Asynchronous`) in Jakarta Concurrency,

https://github.com/jakartaee/concurrency/blob/ce3665a5d8819d91b1d34deab8a4e26d8d9b1fac/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java#L171-L172

We would definitely want the `@Lock` interceptor to run after `@Asynchronous` because it is valuable to lock the execution of the bean method that runs the user's code, rather than the opposite order which would lock only the request to submit an asynchronous task, but not the user's code in the bean method.

Another interceptor in Jakarta EE is `@Transactional`,

> The Transactional interceptors must have a priority of Interceptor.Priority.PLATFORM_BEFORE+200

It makes sense to obtain the lock prior to starting a transaction on the thread so that any lock wait does not use up part of the transaction timeout.

One possibility would be to choose a value around Interceptor.Priority.PLATFORM_BEFORE+100 which is nearly halfway between the `@Asynchronous` priority and `@Transactional` priority.  That's what I have done in this PR lacking any reason to aim for a value closer to one end or the other.

Also, this PR includes changes to make Javadoc links to some other Jakarta specs work correctly.