### PR TITLE
Clarify behavior when both bean method and class have a Lock anno

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -38,8 +38,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * mode, by invoking bean methods. If the bean implementation internally accesses
  * one of its own methods or fields, that access is not subject to the lock.</p>
  *
- * <p>A {@code Lock} annotation on a bean method takes precedence over a
- * {@code Lock} on the bean class.
+ * <p>A {@code Lock} annotation on a bean method takes precedence over and
+ * fully replaces a {@code Lock} annotation on the bean class.
  * A bean method that does not have a {@code Lock} annotation inherits the
  * {@code Lock} annotation, if present, of the class that declares the method.
  * If neither the bean method nor the bean class are annotated {@code Lock},

--- a/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Lock.java
@@ -38,8 +38,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * mode, by invoking bean methods. If the bean implementation internally accesses
  * one of its own methods or fields, that access is not subject to the lock.</p>
  *
- * <p>A bean method that does not have a {@code Lock} annotation inherits
- * the {@code Lock} annotation, if present, of the class that declares the method.
+ * <p>A {@code Lock} annotation on a bean method takes precedence over a
+ * {@code Lock} on the bean class.
+ * A bean method that does not have a {@code Lock} annotation inherits the
+ * {@code Lock} annotation, if present, of the class that declares the method.
  * If neither the bean method nor the bean class are annotated {@code Lock},
  * then invocation of the method does not require a lock to be obtained.</p>
  *


### PR DESCRIPTION
I was writing some TCK tests for the Lock annotation and realized that we need to clarify what behavior to expect when both the bean method and its class have Lock annotations.  I would say that the more useful behavior is that the more granular method level annotation takes precedence, which is what I included in this PR.