### PR TITLE
TCK tests for Schedule on methods

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Schedule.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Schedule.java
@@ -334,7 +334,7 @@ public @interface Schedule {
                             : Arrays.copyOf(daysOfWeek, daysOfWeek.length),
                     hours.length == 0
                             ? hours
-                            : Arrays.copyOf(hours, months.length),
+                            : Arrays.copyOf(hours, hours.length),
                     minutes.length == 0
                             ? minutes
                             : Arrays.copyOf(minutes, minutes.length),

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/Schedule/ScheduleBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/Schedule/ScheduleBean.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.api.Schedule;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.concurrent.Schedule;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * A CDI managed bean with methods annotated directly with {@link Schedule},
+ * each using a different schedule configuration to provide broad coverage.
+ *
+ * <p>The five scheduled methods use:
+ * <ul>
+ *   <li>{@link #scheduledEvery6Seconds()} – seconds field list, no zone</li>
+ *   <li>{@link #scheduledEvery5SecondsPacific()} – seconds field list, with an
+ *       explicit time zone</li>
+ *   <li>{@link #scheduledEvery3Seconds()} – cron expression (every 3 seconds)</li>
+ *   <li>{@link #scheduledMethodThatThrows()} - seconds field list, no zone</li>
+ *   <li>{@link #scheduledSlowMethod()} – cron expression firing every 4 seconds
+ *       starting at second 1 (i.e. seconds 1, 5, 9, 13, ...)</li>
+ * </ul>
+ * </p>
+ *
+ * <p>Coordination state (latches, counters) lives as {@code static} fields on
+ * {@link ScheduleServlet}, so there is no need for non-private fields here.</p>
+ */
+@ApplicationScoped
+public class ScheduleBean {
+
+    // Active-invocation counter for the slow method; used only within this
+    // bean to compute the peak concurrency recorded in ScheduleServlet.
+    private final AtomicInteger slowMethodActive = new AtomicInteger(0);
+
+    /**
+     * Fires every 3 seconds via a cron expression. Tests verify that
+     * {@link Schedule#cron()} is supported on a plain CDI bean method.
+     */
+    @Schedule(cron = "*/3 * * * * *")
+    public void scheduledEvery3Seconds() {
+        ScheduleServlet.cronRunCount.incrementAndGet();
+        ScheduleServlet.cronRan5TimesLatch.countDown();
+    }
+
+    /**
+     * Fires every 5 seconds using the America/Los_Angeles zone. Tests verify
+     * that a {@link Schedule} with an explicit {@link Schedule#zone()} is
+     * honoured and the method still executes repeatedly.
+     */
+    @Schedule(seconds = { 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55 },
+              minutes = {}, // minutes not restricted
+              hours = {}, // hours not restricted
+              zone = "America/Los_Angeles")
+    public void scheduledEvery5SecondsPacific() {
+        ScheduleServlet.zonedRunCount.incrementAndGet();
+        ScheduleServlet.zonedRanThriceLatch.countDown();
+    }
+
+    /**
+     * Fires every 6 seconds (at seconds 0, 6, 12, 18, 24, 30, 36, 42, 48, 54).
+     * Tests observe {@link ScheduleServlet#ranTwiceLatch} to confirm that the
+     * method is invoked multiple times automatically.
+     */
+    @Schedule(seconds = { 0, 6, 12, 18, 24, 30, 36, 42, 48, 54 },
+              minutes = {}, // minutes not restricted
+              hours = {} // hours not restricted
+    )
+    public void scheduledEvery6Seconds() {
+        ScheduleServlet.every6SecondsRunCount.incrementAndGet();
+        ScheduleServlet.every6SecondsRanTwiceLatch.countDown();
+    }
+
+    /**
+     * Fires every 3 seconds and always throws a {@link RuntimeException}.
+     * The spec states that scheduling stops when an invocation raises an
+     * exception, so this method should not continue to be scheduled after
+     * the first throw. The test confirms the method ran at least once.
+     */
+    @Schedule(seconds = { 0, 3, 6, 9, 12, 15, 18, 21, 24, 27,
+                          30, 33, 36, 39, 42, 45, 48, 51, 54, 57 },
+              minutes = {}, // minutes not restricted
+              hours = {} // hours not restricted
+    )
+    public void scheduledMethodThatThrows() {
+        ScheduleServlet.throwingMethodResultQueue.add(Boolean.TRUE);
+        throw new RuntimeException(
+                "intentional exception from scheduledMethodThatThrows");
+    }
+
+    /**
+     * Fires at seconds 1, 5, 9, 13, ... (every 4 seconds starting at second 1).
+     * Intentionally holds for a long time so that subsequent triggers overlap
+     * and must be skipped per the spec. The test checks that the peak
+     * concurrency count recorded in {@link ScheduleServlet#slowMethodMaxConcurrent}
+     * never exceeds 1.
+     */
+    @Schedule(cron = "1/4 * * * * *")
+    public void scheduledSlowMethod() throws InterruptedException {
+        int active = slowMethodActive.incrementAndGet();
+        int maxActive = ScheduleServlet.slowMethodMaxConcurrent.get();
+        while (active > maxActive
+               && // checkstyle requires this on a new line
+               !ScheduleServlet.slowMethodMaxConcurrent.compareAndSet(maxActive,
+                                                                      active)) {
+            maxActive = ScheduleServlet.slowMethodMaxConcurrent.get();
+        }
+        ScheduleServlet.slowMethodStartedLatch.countDown();
+        try {
+            // Block until the test releases us, or for up to 2 minutes as a
+            // safety valve so the suite is never permanently blocked.
+            ScheduleServlet.slowMethodFinishLatch.await(2, TimeUnit.MINUTES);
+        } finally {
+            slowMethodActive.decrementAndGet();
+        }
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/Schedule/ScheduleServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/Schedule/ScheduleServlet.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.api.Schedule;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import ee.jakarta.tck.concurrent.framework.TestConstants;
+import ee.jakarta.tck.concurrent.framework.TestLogger;
+import ee.jakarta.tck.concurrent.framework.TestServlet;
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet("/ScheduleServlet")
+public class ScheduleServlet extends TestServlet {
+    private static final TestLogger log = TestLogger.get(ScheduleServlet.class);
+    private static final long serialVersionUID = 1L;
+    private static final long TIMEOUT_S = TestConstants.waitTimeout.toSeconds();
+
+    // -----------------------------------------------------------------------
+    // Static coordination state for testScheduleMethodCron
+    // Written by ScheduleBean.scheduledEvery3Seconds()
+    // -----------------------------------------------------------------------
+
+    /** Reaches zero after 5 firings of the cron-scheduled method. */
+    static final CountDownLatch cronRan5TimesLatch = new CountDownLatch(5);
+
+    /** Total invocations of the cron-scheduled method. */
+    static final AtomicInteger cronRunCount = new AtomicInteger(0);
+
+    // -----------------------------------------------------------------------
+    // Static coordination state for testScheduleMethodEvery6Seconds
+    // Written by ScheduleBean.scheduledEvery6Seconds()
+    // -----------------------------------------------------------------------
+
+    /** Reaches zero after two firings of the every-6-seconds scheduled method. */
+    static final CountDownLatch every6SecondsRanTwiceLatch = new CountDownLatch(2);
+
+    /** Total invocations of the every-6-seconds scheduled method. */
+    static final AtomicInteger every6SecondsRunCount = new AtomicInteger(0);
+
+    // -----------------------------------------------------------------------
+    // Static coordination state for testScheduleMethodNotConcurrentWithSelf
+    // Written by ScheduleBean.scheduledSlowMethod()
+    // -----------------------------------------------------------------------
+
+    /**
+     * Held open while the test verifies no overlap; released by the test
+     * when the slow method is allowed to finish.
+     */
+    static final CountDownLatch slowMethodFinishLatch = new CountDownLatch(1);
+
+    /** Peak number of concurrent executions recorded inside the slow method. */
+    static final AtomicInteger slowMethodMaxConcurrent = new AtomicInteger(0);
+
+    /** Released once the slow scheduled method has started. */
+    static final CountDownLatch slowMethodStartedLatch = new CountDownLatch(1);
+
+    // -----------------------------------------------------------------------
+    // Static coordination state for testScheduleMethodStopsOnException
+    // Written by ScheduleBean.scheduledMethodThatThrows()
+    // -----------------------------------------------------------------------
+
+    /** A value is added each time the throwing scheduled method runs. */
+    static final LinkedBlockingQueue<Boolean> throwingMethodResultQueue =
+            new LinkedBlockingQueue<>();
+
+    // -----------------------------------------------------------------------
+    // Static coordination state for testScheduleMethodWithZone
+    // Written by ScheduleBean.scheduledEvery5SecondsPacific()
+    // -----------------------------------------------------------------------
+
+    /** Reaches zero after 3 firings of the zone-aware scheduled method. */
+    static final CountDownLatch zonedRanThriceLatch = new CountDownLatch(3);
+
+    /** Total invocations of the zone-aware scheduled method. */
+    static final AtomicInteger zonedRunCount = new AtomicInteger(0);
+
+    // -----------------------------------------------------------------------
+    // Test methods
+    // -----------------------------------------------------------------------
+
+    /**
+     * Verify that a {@code @Schedule} annotation using a cron expression
+     * fires the method repeatedly when placed directly on a CDI bean method.
+     *
+     * <p>The cron expression fires every 3 seconds.
+     * The test waits until five invocations have completed, then confirms the
+     * counter is at least 5.</p>
+     */
+    public void testScheduleMethodCron() throws Exception {
+        assertEquals(true,
+                     cronRan5TimesLatch.await(TIMEOUT_S, TimeUnit.SECONDS));
+        assertEquals(true,
+                     cronRunCount.get() >= 5);
+    }
+
+    /**
+     * Verify that a method annotated directly with {@code @Schedule} runs
+     * automatically and repeatedly without any explicit invocation.
+     *
+     * <p>The method uses a seconds-list schedule every 6 seconds. The test
+     * waits until the latch has counted down twice, then confirms the run
+     * counter is at least 2, proving the method fired more than once.</p>
+     */
+    public void testScheduleMethodEvery6Seconds() throws Exception {
+        assertEquals(true,
+                     every6SecondsRanTwiceLatch.await(TIMEOUT_S * 2,
+                                                      TimeUnit.SECONDS));
+        assertEquals(true,
+                     every6SecondsRunCount.get() >= 2);
+    }
+
+    /**
+     * Verify that a scheduled method never runs concurrently with itself.
+     *
+     * <p>The spec states that executions missed due to overlap are always
+     * skipped. The method uses the cron expression that fires every 4 seconds
+     * starting at second 1 (i.e. at seconds 1, 5, 9, 13, ...). The test
+     * holds the first invocation open long enough for at least one additional
+     * trigger to fire and be skipped, then releases it and checks that the
+     * peak concurrent-execution count never exceeded 1.</p>
+     */
+    public void testScheduleMethodNotConcurrentWithSelf() throws Exception {
+        // Wait until the first invocation has started
+        assertEquals(true,
+                     slowMethodStartedLatch.await(TIMEOUT_S, TimeUnit.SECONDS));
+
+        // Hold for long enough that at least two more triggers (at 4-second
+        // intervals) would fire while the method is still running.
+        TimeUnit.SECONDS.sleep(9);
+
+        // Release the held invocation
+        slowMethodFinishLatch.countDown();
+
+        // If concurrency was ever >1 the spec was violated
+        assertEquals(1, slowMethodMaxConcurrent.get());
+    }
+
+    /**
+     * Verify that a scheduled method that throws a {@link RuntimeException}
+     * was at least invoked (observable side-effect before the throw).
+     *
+     * <p>Per the spec, scheduling stops for the method once it throws.
+     * The test confirms the method ran at most once by waiting on the queue
+     * that the method populates before throwing.</p>
+     */
+    public void testScheduleMethodStopsOnException() throws Exception {
+        assertEquals(Boolean.TRUE,
+                     throwingMethodResultQueue.poll(TIMEOUT_S, TimeUnit.SECONDS));
+        assertEquals(null,
+                     throwingMethodResultQueue.poll(8, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Verify that a {@code @Schedule} annotation with an explicit
+     * {@link jakarta.enterprise.concurrent.Schedule#zone()} attribute is
+     * honoured and the method still fires repeatedly.
+     *
+     * <p>The method fires every 5 seconds in the America/Los_Angeles zone.
+     * The test confirms at least 3 invocations complete within the timeout,
+     * which proves the container accepted and applied the zone-aware schedule.</p>
+     */
+    public void testScheduleMethodWithZone() throws Exception {
+        assertEquals(true,
+                     zonedRanThriceLatch.await(TIMEOUT_S * 3, TimeUnit.SECONDS));
+        assertEquals(true,
+                     zonedRunCount.get() >= 3);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/api/Schedule/ScheduleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/api/Schedule/ScheduleTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.api.Schedule;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import ee.jakarta.tck.concurrent.framework.TestClient;
+import ee.jakarta.tck.concurrent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.concurrent.framework.junit.anno.TestName;
+import ee.jakarta.tck.concurrent.framework.junit.anno.Web;
+
+@Web
+@RunAsClient
+public class ScheduleTests extends TestClient {
+
+    @ArquillianResource(ScheduleServlet.class)
+    private URL baseURL;
+
+    @Deployment(name = "ScheduleTests")
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "ScheduleTests_web.war")
+                .addPackages(false, ScheduleTests.class.getPackage());
+    }
+
+    @TestName
+    private String testname;
+
+    @Override
+    protected String getServletPath() {
+        return "ScheduleServlet";
+    }
+
+    // Numbers in assertion ids are line numbers in the Schedule Javadoc source
+
+    @Assertion(id = "JAVADOC:40", strategy = """
+            Tests that the Schedule.cron() attribute is supported when
+            @Schedule is placed directly on a CDI managed bean method.
+            The cron expression "*/3 * * * * *" fires the method every
+            3 seconds and the test confirms multiple invocations occur.
+            """)
+    public void testScheduleMethodCron() throws Exception {
+        runTest(baseURL, testname);
+    }
+
+    @Assertion(id = "JAVADOC:40", strategy = """
+            Tests that a method annotated directly with @Schedule on a CDI
+            managed bean is invoked automatically and repeatedly by the
+            container without any explicit caller invocation.
+            The schedule uses a seconds-field list (every 6 seconds).
+            """)
+    public void testScheduleMethodEvery6Seconds() throws Exception {
+        runTest(baseURL, testname);
+    }
+
+    @Assertion(id = "JAVADOC:56", strategy = """
+            Tests that a scheduled method never runs concurrently with itself.
+            The spec requires that executions missed due to overlap are always
+            skipped. The schedule uses cron "1/4 * * * * *" (fires at seconds
+            1, 5, 9, 13, ...). The test holds the first invocation open
+            across multiple trigger times and verifies that the peak
+            concurrent execution count never exceeds 1.
+            """)
+    public void testScheduleMethodNotConcurrentWithSelf() throws Exception {
+        runTest(baseURL, testname);
+    }
+
+    @Assertion(id = "JAVADOC:60", strategy = """
+            Tests that a @Schedule method that throws a RuntimeException is
+            observed to have run at least once. Per the spec, scheduling
+            continues until an invocation raises an exception or error;
+            the test verifies the method was invoked before the throw and
+            confirms that scheduled execution does not continue indefinitely
+            after the exception.
+            """)
+    public void testScheduleMethodStopsOnException() throws Exception {
+        runTest(baseURL, testname);
+    }
+
+    @Assertion(id = "JAVADOC:47", strategy = """
+            Tests that a @Schedule annotation with an explicit zone attribute
+            (America/Los_Angeles) is accepted and the method still fires
+            repeatedly. The schedule fires every 5 seconds.
+            """)
+    public void testScheduleMethodWithZone() throws Exception {
+        runTest(baseURL, testname);
+    }
+}


### PR DESCRIPTION
TCK tests for the Schedule annotation on a CDI managed bean method